### PR TITLE
v2.0.0

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -10,6 +10,20 @@ export interface IEthereumProviderError<T> extends IEthereumRpcError<T> {}
 
 type DefaultError = { code: number, message: string }
 
+export interface IErrorOptions {
+  message?: string | null,
+  data?: any,
+}
+
+export interface IRpcServerErrorOptions extends IErrorOptions {
+  code: number,
+}
+
+export interface IProviderCustomErrorOptions extends IErrorOptions {
+  code: number,
+  message: string,
+}
+
 export interface ISerializeError {
   (error: any, fallbackError?: DefaultError): IEthereumRpcError<any>
 }
@@ -18,25 +32,25 @@ export interface IGetMessageFromCode {
   (error: any, fallbackMessage?: string): string
 }
 
-export interface IRpcErrors {
+export interface IEthErrors {
   rpc: {
-    invalidInput: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    resourceNotFound: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    resourceUnavailable: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    transactionRejected: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    methodNotSupported: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    parse: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    invalidRequest: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    invalidParams: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    methodNotFound: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    internal: (message?: string | null, data?: any) => IEthereumRpcError<any>,
-    server: (code: number, message?: string | null, data?: any) => IEthereumRpcError<any>,
+    invalidInput: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    resourceNotFound: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    resourceUnavailable: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    transactionRejected: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    methodNotSupported: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    parse: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    invalidRequest: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    invalidParams: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    methodNotFound: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    internal: (opts?: string | IErrorOptions) => IEthereumRpcError<any>,
+    server: (opts: IRpcServerErrorOptions) => IEthereumRpcError<any>,
   },
   provider: {
-    userRejectedRequest: (message?: string | null, data?: any) => IEthereumProviderError<any>,
-    unauthorized: (message?: string | null, data?: any) => IEthereumProviderError<any>,
-    unsupportedMethod: (message?: string | null, data?: any) => IEthereumProviderError<any>,
-    custom: (code: number, message: string | null, data?: any) => IEthereumProviderError<any>,
+    userRejectedRequest: (opts?: string | IErrorOptions) => IEthereumProviderError<any>,
+    unauthorized: (opts?: string | IErrorOptions) => IEthereumProviderError<any>,
+    unsupportedMethod: (opts?: string | IErrorOptions) => IEthereumProviderError<any>,
+    custom: (opts: IProviderCustomErrorOptions) => IEthereumProviderError<any>,
   }
 }
 

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,17 +1,17 @@
 
-export interface IJsonRpcError<T> {
+export interface IEthereumRpcError<T> {
   code: number; // must be an integer
   message: string;
   data?: T;
   stack?: any; // non-standard but not forbidden, and useful if it exists
 }
 
-export interface IEthJsonRpcError<T> extends IJsonRpcError<T> {}
+export interface IEthereumProviderError<T> extends IEthereumRpcError<T> {}
 
 type DefaultError = { code: number, message: string }
 
 export interface ISerializeError {
-  (error: any, fallbackError?: DefaultError): IJsonRpcError<any>
+  (error: any, fallbackError?: DefaultError): IEthereumRpcError<any>
 }
 
 export interface IGetMessageFromCode {
@@ -19,17 +19,24 @@ export interface IGetMessageFromCode {
 }
 
 export interface IRpcErrors {
-  parse: (message?: string | null, data?: any) => IJsonRpcError<any>,
-  invalidRequest: (message?: string | null, data?: any) => IJsonRpcError<any>,
-  invalidParams: (message?: string | null, data?: any) => IJsonRpcError<any>,
-  methodNotFound: (message?: string | null, data?: any) => IJsonRpcError<any>,
-  internal: (message?: string | null, data?: any) => IJsonRpcError<any>,
-  server: (code: number, message?: string | null, data?: any) => IJsonRpcError<any>,
-  eth: {
-    userRejectedRequest: (message?: string | null, data?: any) => IEthJsonRpcError<any>,
-    unauthorized: (message?: string | null, data?: any) => IEthJsonRpcError<any>,
-    unsupportedMethod: (message?: string | null, data?: any) => IEthJsonRpcError<any>,
-    custom: (code: number, message: string | null, data?: any) => IEthJsonRpcError<any>,
+  rpc: {
+    invalidInput: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    resourceNotFound: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    resourceUnavailable: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    transactionRejected: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    methodNotSupported: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    parse: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    invalidRequest: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    invalidParams: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    methodNotFound: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    internal: (message?: string | null, data?: any) => IEthereumRpcError<any>,
+    server: (code: number, message?: string | null, data?: any) => IEthereumRpcError<any>,
+  },
+  provider: {
+    userRejectedRequest: (message?: string | null, data?: any) => IEthereumProviderError<any>,
+    unauthorized: (message?: string | null, data?: any) => IEthereumProviderError<any>,
+    unsupportedMethod: (message?: string | null, data?: any) => IEthereumProviderError<any>,
+    custom: (code: number, message: string | null, data?: any) => IEthereumProviderError<any>,
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
       - `ethErrors.provider.custom` must receive a single of the form:
         - `{ code: number, message: string, data?: any }
 - **TypeScript**
-  - Updated affected TypeScript interfaces
+  - Updated affected interfaces
 
 ## 1.1.0
 - `serializeError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## 2.0.0 (Current)
-- **Exports:** `errors` renamed `ethErrors`
+- **Exports**
+  - `errors` renamed `ethErrors`
+  - `JsonRpcError` renamed `EthereumRpcError`
+  - `EthJsonRpcError` renamed `EthereumProviderError`
+    - It is still a subclass of `EthereumRpcError`
 - `ethErrors`
   - Added missing
   [EIP 1474 errors](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
@@ -15,19 +19,16 @@
   is either a string or an object
     - If a string, it becomes the error message
     - If an object, it should have the form: `{ message?: string, data?: any }`
-    - **Exceptions**
+    - **Special Cases**
       - `ethErrors.rpc.server` must receive a single object of the form:
         - `{ code: number, message?: string, data?: any }
       - `ethErrors.provider.custom` must receive a single of the form:
         - `{ code: number, message: string, data?: any }
-- **Error Classes**
-  - `JsonRpcError` renamed `EthereumRpcError`
-  - `EthJsonRpcError` renamed `EthereumProviderError`
-    - It is still a subclass of `EthereumRpcError`
 - **TypeScript**
   - Updated affected TypeScript interfaces and names
 
 ## 1.1.0
-- `serializeError` if the object passed to the function has a `.message` property,
-it will preferred over the `.message` property of the fallback error when
-creating the returned serialized error object
+- `serializeError`
+  - If the object passed to the function has a `.message` property,
+  it will preferred over the `.message` property of the fallback error when
+  creating the returned serialized error object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 2.0.0 (Current)
+- **Exports:** `errors` renamed `ethErrors`
+- `ethErrors`
+  - Added missing
+  [EIP 1474 errors](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
+    - Added corresponding codes and messages
+  - **Namespacing**
+    - EIP 1474 (which includes JSON RPC 2.0) errors now namespaced under `ethErrors.rpc`
+      - JSON RPC 2.0 errors were formerly under `errors.jsonRpc`
+    - EIP 1193 errors now namespaced under `ethErrors.provider`
+      - Formerly under `errors.eth`
+  - Most error getters now take a single, *optional* `opts` argument, which
+  is either a string or an object
+    - If a string, it becomes the error message
+    - If an object, it should have the form: `{ message?: string, data?: any }`
+    - **Exceptions**
+      - `ethErrors.rpc.server` must receive a single object of the form:
+        - `{ code: number, message?: string, data?: any }
+      - `ethErrors.provider.custom` must receive a single of the form:
+        - `{ code: number, message: string, data?: any }
+- **Error Classes**
+  - `JsonRpcError` renamed `EthereumRpcError`
+  - `EthJsonRpcError` renamed `EthereumProviderError`
+    - It is still a subclass of `EthereumRpcError`
+- **TypeScript**
+  - Updated affected TypeScript interfaces and names
+
+## 1.1.0
+- `serializeError` if the object passed to the function has a `.message` property,
+it will preferred over the `.message` property of the fallback error when
+creating the returned serialized error object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - `JsonRpcError` renamed `EthereumRpcError`
   - `EthJsonRpcError` renamed `EthereumProviderError`
     - It is still a subclass of `EthereumRpcError`
+  - **TypeScript**
+    - Renamed affected interfaces
 - `ethErrors`
   - Added missing
   [EIP 1474 errors](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
@@ -25,7 +27,7 @@
       - `ethErrors.provider.custom` must receive a single of the form:
         - `{ code: number, message: string, data?: any }
 - **TypeScript**
-  - Updated affected TypeScript interfaces and names
+  - Updated affected TypeScript interfaces
 
 ## 1.1.0
 - `serializeError`

--- a/README.md
+++ b/README.md
@@ -75,9 +75,6 @@ response.error = ethErrors.provider.custom({
 
 ### Parsing Unknown Errors
 ```js
-/**
- * serializeError
- */
 // this is useful for ensuring your errors are standardized
 import { serializeError } from 'eth-json-rpc-errors'
 

--- a/README.md
+++ b/README.md
@@ -18,39 +18,39 @@ Import using ES6 syntax (no default) or Node `require`.
 ### Errors API
 
 ```js
-import { errors as rpcErrors } from 'eth-json-rpc-errors'
+import { errors as ethErrors } from 'eth-json-rpc-errors'
 
-// standard JSON RPC 2.0 errors namespaced directly under rpcErrors
-response.error = rpcErrors.methodNotFound(
+// standard JSON RPC 2.0 errors namespaced directly under ethErrors
+response.error = ethErrors.rpc.methodNotFound(
   optionalCustomMessage, optionalData
 )
 
-// ETH JSON RPC errors namespaced under rpcErrors.eth
-response.error = rpcErrors.eth.unauthorized(
+// ETH JSON RPC errors namespaced under ethErrors.provider
+response.error = ethErrors.provider.unauthorized(
   optionalCustomMessage, optionalData
 )
 
 // the message can be falsy or a string
 // a falsy message will produce an error with a default message
-response.error = rpcErrors.eth.unauthorized(null, optionalData)
+response.error = ethErrors.provider.unauthorized(null, optionalData)
 
 // omitting the data argument will produce an error without a
 // "data" property
-response.error = rpcErrors.eth.unauthorized(optionalCustomMessage)
+response.error = ethErrors.provider.unauthorized(optionalCustomMessage)
 
 // both arguments can be omitted for almost all errors
-response.error = rpcErrors.eth.unauthorized()
-response.error = rpcErrors.methodNotFound()
+response.error = ethErrors.provider.unauthorized()
+response.error = ethErrors.rpc.methodNotFound()
 
 // the JSON RPC 2.0 server error requires a valid code
-response.error = rpcErrors.server(
+response.error = ethErrors.rpc.server(
   -32031, optionalCustomMessage, optionalData
 )
 
 // there's an option for custom ETH errors
 // it requires a valid code and a string message
 // valid codes are integers i such that: 1000 <= i <= 4999
-response.error = rpcErrors.eth.custom(
+response.error = ethErrors.provider.custom(
   1001, requiredMessage, optionalData
 )
 ```
@@ -67,7 +67,7 @@ import {
 /**
  * Classes
  */
-import { JsonRpcError, EthJsonRpcError } from 'eth-json-rpc-errors'
+import { JsonRpcError, EthereumRpcError } from 'eth-json-rpc-errors'
 
 /**
  * serializeError
@@ -107,8 +107,8 @@ const message3 = getMessageFromCode(someCode, null)
 //   jsonRpc: { [errorName]: code, ... },
 //   eth: { [errorName]: code, ... },
 // }
-const code1 = ERROR_CODES.jsonRpc.parse
-const code2 = ERROR_CODES.eth.userRejectedRequest
+const code1 = ERROR_CODES.rpc.parse
+const code2 = ERROR_CODES.provider.userRejectedRequest
 
 // all codes in ERROR_CODES have default messages
 const message4 = getMessageFromCode(code1)

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 
-const { JsonRpcError, EthJsonRpcError } = require('./src/classes')
+const { EthereumRpcError, EthereumProviderError } = require('./src/classes')
 const {
   serializeError, getMessageFromCode,
 } = require('./src/utils')
-const errors = require('./src/errors')
+const ethErrors = require('./src/errors')
 const ERROR_CODES = require('./src/errorCodes.json')
 
 module.exports = {
-  errors,
-  JsonRpcError,
-  EthJsonRpcError,
+  ethErrors,
+  EthereumRpcError,
+  EthereumProviderError,
   serializeError,
   getMessageFromCode,
   /** @type ErrorCodes */
@@ -19,23 +19,28 @@ module.exports = {
 // Types
 
 /**
- * @typedef {Object} EthJsonRpcErrorCodes
+ * @typedef {Object} EthereumProviderErrorCodes
  * @property {number} userRejectedRequest
  * @property {number} unauthorized
  * @property {number} unsupportedMethod
  */
 
 /**
- * @typedef {Object} JsonRpcErrorCodes
+ * @typedef {Object} EthereumRpcErrorCodes
  * @property {number} parse
  * @property {number} invalidRequest
  * @property {number} invalidParams
  * @property {number} methodNotFound
  * @property {number} internal
+ * @property {number} invalidInput
+ * @property {number} resourceNotFound
+ * @property {number} resourceUnavailable
+ * @property {number} transactionRejected
+ * @property {number} methodNotSupported
  */
 
 /**
  * @typedef ErrorCodes
- * @property {JsonRpcErrorCodes} jsonRpc
- * @property {EthJsonRpcErrorCodes} eth
+ * @property {EthereumRpcErrorCodes} rpc
+ * @property {EthereumProviderErrorCodes} provider
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,47 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+      "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.6.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -22,6 +63,51 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+      "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+      "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.6.2",
+        "@babel/types": "^7.6.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/types": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "acorn": {
@@ -69,6 +155,21 @@
         "color-convert": "^1.9.0"
       }
     },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -100,10 +201,28 @@
         "concat-map": "0.0.1"
       }
     },
+    "caching-transform": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "dev": true,
+      "requires": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "chalk": {
@@ -138,6 +257,30 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -153,11 +296,46 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true,
+      "optional": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cp-file": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^2.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^4.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -189,6 +367,12 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -200,6 +384,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -231,6 +424,15 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
@@ -255,6 +457,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -431,6 +639,26 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -457,6 +685,28 @@
         "is-callable": "^1.1.3"
       }
     },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -473,6 +723,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "glob": {
@@ -504,6 +760,32 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -523,6 +805,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
     },
     "iconv-lite": {
@@ -593,6 +890,12 @@
         "through": "^2.3.6"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -641,6 +944,12 @@
         "has": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -655,6 +964,88 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -671,6 +1062,18 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -694,11 +1097,92 @@
         "type-check": "~0.3.2"
       }
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -756,11 +1240,76 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "nyc": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "caching-transform": "^3.0.2",
+        "convert-source-map": "^1.6.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.2.3",
+        "uuid": "^3.3.2",
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -792,6 +1341,30 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -806,11 +1379,53 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -820,6 +1435,22 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -839,6 +1470,38 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -851,16 +1514,64 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -924,6 +1635,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -934,6 +1651,12 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
@@ -967,6 +1690,58 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "spawn-wrap": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1022,6 +1797,12 @@
           "dev": true
         }
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -1084,6 +1865,18 @@
         "through": "~2.3.8"
       }
     },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1105,6 +1898,12 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -1120,6 +1919,26 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "uglify-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1129,11 +1948,27 @@
         "punycode": "^2.1.0"
       }
     },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -1144,11 +1979,41 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1163,6 +2028,70 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-json-rpc-errors",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node test",
+    "test:coverage": "nyc tape test",
     "lint": "./node_modules/.bin/eslint index.js",
     "lint:fix": "./node_modules/.bin/eslint index.js --fix",
     "prepare": "npm run lint:fix && npm run test"
@@ -29,6 +30,7 @@
   "devDependencies": {
     "eslint": "^6.1.0",
     "fast-deep-equal": "^2.0.1",
+    "nyc": "^14.1.1",
     "tape": "^4.11.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-json-rpc-errors",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Ethereum JSON RPC errors and standard JSON RPC 2.0 errors.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth-json-rpc-errors",
   "version": "2.0.0",
-  "description": "Ethereum JSON RPC errors and standard JSON RPC 2.0 errors.",
+  "description": "Ethereum JSON RPC and Provider errors.",
   "main": "index.js",
   "scripts": {
     "test": "node test",

--- a/src/classes.js
+++ b/src/classes.js
@@ -3,13 +3,15 @@ const safeStringify = require('fast-safe-stringify')
 
 /**
  * @class JsonRpcError
- * Error subclass implementing JSON RPC 2.0 errors.
+ * Error subclass implementing JSON RPC 2.0 errors and Ethereum RPC errors
+ * per EIP 1474.
  * Permits any integer error code.
  */
-class JsonRpcError extends Error {
+class EthereumRpcError extends Error {
 
   /**
-   * Create a JSON RPC error.
+   * Create an Ethereum JSON RPC error.
+   * 
    * @param {number} code - The integer error code.
    * @param {string} message - The string message.
    * @param {any} [data] - The error data.
@@ -30,6 +32,7 @@ class JsonRpcError extends Error {
 
   /**
    * Returns a plain object with all public class properties.
+   * 
    * @returns {object} The serialized error. 
    */
   serialize() {
@@ -45,6 +48,7 @@ class JsonRpcError extends Error {
   /**
    * Return a string representation of the serialized error, omitting
    * any circular references.
+   * 
    * @returns {string} The serialized error as a string.
    */
   toString() {
@@ -57,19 +61,20 @@ class JsonRpcError extends Error {
 }
 
 /**
- * @class EthJsonRpcError
- * Error subclass implementing Ethereum JSON RPC errors.
+ * @class EthereumRpcError
+ * Error subclass implementing Ethereum Provider errors per EIP 1193.
  * Permits integer error codes in the [ 1000 <= 4999 ] range.
  */
-class EthJsonRpcError extends JsonRpcError {
+class EthereumProviderError extends EthereumRpcError {
   /**
    * Create an Ethereum JSON RPC error.
+   * 
    * @param {number} code - The integer error code, in the [ 1000 <= 4999 ] range.
    * @param {string} message - The string message.
    * @param {any} [data] - The error data.
    */
   constructor(code, message, data) {
-    if (!isValidEthCode(code)) {
+    if (!isValidEthProviderCode(code)) {
       throw new Error(
         '"code" must be an integer such that: 1000 <= code <= 4999'
       )
@@ -80,7 +85,7 @@ class EthJsonRpcError extends JsonRpcError {
 
 // Internal
 
-function isValidEthCode(code) {
+function isValidEthProviderCode(code) {
   return Number.isInteger(code) && code >= 1000 && code <= 4999
 }
 
@@ -94,6 +99,6 @@ function stringifyReplacer(_, value) {
 // Exports
 
 module.exports =  {
-  JsonRpcError,
-  EthJsonRpcError,
+  EthereumRpcError,
+  EthereumProviderError
 }

--- a/src/errorCodes.json
+++ b/src/errorCodes.json
@@ -1,12 +1,17 @@
 {
-  "jsonRpc": {
-      "parse": -32700,
-      "invalidRequest": -32600,
-      "methodNotFound": -32601,
-      "invalidParams": -32602,
-      "internal": -32603
+  "rpc": {
+    "invalidInput": -32000,
+    "resourceNotFound": -32001,
+    "resourceUnavailable": -32002,
+    "transactionRejected": -32003,
+    "methodNotSupported": -32004,
+    "parse": -32700,
+    "invalidRequest": -32600,
+    "methodNotFound": -32601,
+    "invalidParams": -32602,
+    "internal": -32603
   },
-  "eth": {
+  "provider": {
     "userRejectedRequest": 4001,
     "unauthorized": 4100,
     "unsupportedMethod": 4200

--- a/src/errorValues.json
+++ b/src/errorValues.json
@@ -19,6 +19,26 @@
     "standard": "JSON RPC 2.0",
     "message": "Internal JSON-RPC error."
   },
+  "-32000": {
+    "standard": "EIP 1474",
+    "message": "Invalid input."
+  },
+  "-32001": {
+    "standard": "EIP 1474",
+    "message": "Resource not found."
+  },
+  "-32002": {
+    "standard": "EIP 1474",
+    "message": "Resource unavailable."
+  },
+  "-32003": {
+    "standard": "EIP 1474",
+    "message": "Transaction rejected."
+  },
+  "-32004": {
+    "standard": "EIP 1474",
+    "message": "Method not supported."
+  },
   "4001": {
     "standard": "EIP 1193",
     "message": "User rejected the request."

--- a/src/errors.js
+++ b/src/errors.js
@@ -8,9 +8,10 @@ module.exports = {
     /**
      * Get a JSON RPC 2.0 Parse error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     parse: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.parse, opts
@@ -19,9 +20,10 @@ module.exports = {
     /**
      * Get a JSON RPC 2.0 Invalid Request error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     invalidRequest: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.invalidRequest, opts
@@ -30,9 +32,10 @@ module.exports = {
     /**
      * Get a JSON RPC 2.0 Invalid Params error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     invalidParams: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.invalidParams, opts
@@ -41,9 +44,10 @@ module.exports = {
     /**
      * Get a JSON RPC 2.0 Method Not Found error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     methodNotFound: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.methodNotFound, opts
@@ -52,9 +56,10 @@ module.exports = {
     /**
      * Get a JSON RPC 2.0 Internal error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     internal: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.internal, opts
@@ -65,10 +70,11 @@ module.exports = {
      * Permits integer error codes in the [ -32099 <= -32005 ] range.
      * Codes -32000 through -32004 are reserved by EIP 1474.
      * 
-     * @param {number} [code] - The integer error code.
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} opts - Options object
+     * @param {number} opts.code - The error code
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     server: (opts) => {
       if (typeof opts !== 'object' || Array.isArray(opts)) {
@@ -86,9 +92,10 @@ module.exports = {
     /**
      * Get an Ethereum JSON RPC Invalid Input error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     invalidInput: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.invalidInput, opts
@@ -97,9 +104,10 @@ module.exports = {
     /**
      * Get an Ethereum JSON RPC Resource Not Found error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     resourceNotFound: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.resourceNotFound, opts
@@ -108,9 +116,10 @@ module.exports = {
     /**
      * Get an Ethereum JSON RPC Resource Unavailable error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     resourceUnavailable: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.resourceUnavailable, opts
@@ -119,9 +128,10 @@ module.exports = {
     /**
      * Get an Ethereum JSON RPC Transaction Rejected error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     transactionRejected: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.transactionRejected, opts
@@ -130,9 +140,10 @@ module.exports = {
     /**
      * Get an Ethereum JSON RPC Method Not Supported error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumRpcError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumRpcError} - The error
      */
     methodNotSupported: (opts) => getEthJsonRpcError(
       ERROR_CODES.rpc.methodNotSupported, opts
@@ -143,9 +154,10 @@ module.exports = {
     /**
      * Get an Ethereum Provider User Rejected Request error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumProviderError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumProviderError} - The error
      */
     userRejectedRequest: (opts) => {
       return getEthProviderError(
@@ -156,9 +168,10 @@ module.exports = {
     /**
      * Get an Ethereum Provider Unauthorized error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumProviderError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumProviderError} - The error
      */
     unauthorized: (opts) => {
       return getEthProviderError(
@@ -169,9 +182,10 @@ module.exports = {
     /**
      * Get an Ethereum Provider Unsupported Method error.
      * 
-     * @param {string} [message] - A custom message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumProviderError} The error.
+     * @param {Object|string} [opts] - Options object or error message string
+     * @param {string} [opts.message] - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumProviderError} - The error
      */
     unsupportedMethod: (opts) => {
       return getEthProviderError(
@@ -180,12 +194,13 @@ module.exports = {
     },
 
     /**
-     * Get a custom Ethereum provider error.
+     * Get a custom Ethereum Provider error.
      * 
-     * @param {string} [code] - The error code.
-     * @param {string} [message] - The error message.
-     * @param {any} [data] - Error data.
-     * @return {EthereumProviderError} The error.
+     * @param {Object|string} opts - Options object
+     * @param {number} opts.code - The error code
+     * @param {string} opts.message - The error message
+     * @param {any} [opts.data] - Error data
+     * @returns {EthereumProviderError} - The error
      */
     custom: (opts) => {
       if (typeof opts !== 'object' || Array.isArray(opts)) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,142 +1,234 @@
 
-const { JsonRpcError, EthJsonRpcError } = require('./classes')
+const { EthereumRpcError, EthereumProviderError } = require('./classes')
 const { getMessageFromCode } = require('./utils')
 const ERROR_CODES = require('./errorCodes.json')
 
 module.exports = {
-  /**
-   * Get a JSON RPC 2.0 Parse error.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  parse: (message, data) => getJsonRpcError(
-    ERROR_CODES.jsonRpc.parse, message, data
-  ),
+  rpc: {
+    /**
+     * Get a JSON RPC 2.0 Parse error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    parse: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.parse, opts
+    ),
 
-  /**
-   * Get a JSON RPC 2.0 Invalid Request error.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  invalidRequest: (message, data) => getJsonRpcError(
-    ERROR_CODES.jsonRpc.invalidRequest, message, data
-  ),
+    /**
+     * Get a JSON RPC 2.0 Invalid Request error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    invalidRequest: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.invalidRequest, opts
+    ),
 
-  /**
-   * Get a JSON RPC 2.0 Invalid Params error.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  invalidParams: (message, data) => getJsonRpcError(
-    ERROR_CODES.jsonRpc.invalidParams, message, data
-  ),
+    /**
+     * Get a JSON RPC 2.0 Invalid Params error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    invalidParams: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.invalidParams, opts
+    ),
 
-  /**
-   * Get a JSON RPC 2.0 Method Not Found error.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  methodNotFound: (message, data) => getJsonRpcError(
-    ERROR_CODES.jsonRpc.methodNotFound, message, data
-  ),
+    /**
+     * Get a JSON RPC 2.0 Method Not Found error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    methodNotFound: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.methodNotFound, opts
+    ),
 
-  /**
-   * Get a JSON RPC 2.0 Internal error.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  internal: (message, data) => getJsonRpcError(
-    ERROR_CODES.jsonRpc.internal, message, data
-  ),
+    /**
+     * Get a JSON RPC 2.0 Internal error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    internal: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.internal, opts
+    ),
 
-  /**
-   * Get a JSON RPC 2.0 Server error.
-   * Permits integer error codes in the [ -32099 <= -32000 ] range.
-   * @param {number} code - The integer error code.
-   * @param {string} [message] - A custom message.
-   * @param {any} [data] - Error data.
-   * @return {JsonRpcError} The error.
-   */
-  server: (code, message, data) => {
-    if (!Number.isInteger(code) || code > -32000 || code < -32099) {
-      throw new Error(
-        '"code" must be an integer such that: -32099 <= code <= -32000'
-      )
-    }
-    return getJsonRpcError(code, message, data)
+    /**
+     * Get a JSON RPC 2.0 Server error.
+     * Permits integer error codes in the [ -32099 <= -32005 ] range.
+     * Codes -32000 through -32004 are reserved by EIP 1474.
+     * 
+     * @param {number} [code] - The integer error code.
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    server: (opts) => {
+      if (typeof opts !== 'object' || Array.isArray(opts)) {
+        throw new Error('Ethereum RPC Server errors must provide single object argument.')
+      }
+      const { code } = opts
+      if (!Number.isInteger(code) || code > -32005 || code < -32099) {
+        throw new Error(
+          '"code" must be an integer such that: -32099 <= code <= -32005'
+        )
+      }
+      return getEthJsonRpcError(code, opts)
+    },
+
+    /**
+     * Get an Ethereum JSON RPC Invalid Input error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    invalidInput: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.invalidInput, opts
+    ),
+
+    /**
+     * Get an Ethereum JSON RPC Resource Not Found error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    resourceNotFound: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.resourceNotFound, opts
+    ),
+
+    /**
+     * Get an Ethereum JSON RPC Resource Unavailable error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    resourceUnavailable: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.resourceUnavailable, opts
+    ),
+
+    /**
+     * Get an Ethereum JSON RPC Transaction Rejected error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    transactionRejected: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.transactionRejected, opts
+    ),
+
+    /**
+     * Get an Ethereum JSON RPC Method Not Supported error.
+     * 
+     * @param {string} [message] - A custom message.
+     * @param {any} [data] - Error data.
+     * @return {EthereumRpcError} The error.
+     */
+    methodNotSupported: (opts) => getEthJsonRpcError(
+      ERROR_CODES.rpc.methodNotSupported, opts
+    ),
   },
-  eth: {
+
+  provider: {
     /**
-     * Get an Ethereum JSON RPC User Rejected Request error.
+     * Get an Ethereum Provider User Rejected Request error.
+     * 
      * @param {string} [message] - A custom message.
      * @param {any} [data] - Error data.
-     * @return {EthJsonRpcError} The error.
+     * @return {EthereumProviderError} The error.
      */
-    userRejectedRequest: (message, data) => {
-      return getEthJsonRpcError(
-        ERROR_CODES.eth.userRejectedRequest, message, data
+    userRejectedRequest: (opts) => {
+      return getEthProviderError(
+        ERROR_CODES.provider.userRejectedRequest, opts
       )
     },
 
     /**
-     * Get an Ethereum JSON RPC Unauthorized error.
+     * Get an Ethereum Provider Unauthorized error.
+     * 
      * @param {string} [message] - A custom message.
      * @param {any} [data] - Error data.
-     * @return {EthJsonRpcError} The error.
+     * @return {EthereumProviderError} The error.
      */
-    unauthorized: (message, data) => {
-      return getEthJsonRpcError(
-        ERROR_CODES.eth.unauthorized, message, data
+    unauthorized: (opts) => {
+      return getEthProviderError(
+        ERROR_CODES.provider.unauthorized, opts
       )
     },
 
     /**
-     * Get an Ethereum JSON RPC Unsupported Method error.
+     * Get an Ethereum Provider Unsupported Method error.
+     * 
      * @param {string} [message] - A custom message.
      * @param {any} [data] - Error data.
-     * @return {EthJsonRpcError} The error.
+     * @return {EthereumProviderError} The error.
      */
-    unsupportedMethod: (message, data) => {
-      return getEthJsonRpcError(
-        ERROR_CODES.eth.unsupportedMethod, message, data
+    unsupportedMethod: (opts) => {
+      return getEthProviderError(
+        ERROR_CODES.provider.unsupportedMethod, opts
       )
     },
 
     /**
-     * Get a custom Ethereum JSON RPC error.
-     * @param {string} code - The error code.
-     * @param {string} message - The error message.
+     * Get a custom Ethereum provider error.
+     * 
+     * @param {string} [code] - The error code.
+     * @param {string} [message] - The error message.
      * @param {any} [data] - Error data.
-     * @return {EthJsonRpcError} The error.
+     * @return {EthereumProviderError} The error.
      */
-    custom: (code, message, data) => {
+    custom: (opts) => {
+      if (typeof opts !== 'object' || Array.isArray(opts)) {
+        throw new Error('Ethereum Provider custom errors must provide single object argument.')
+      }
+      const { code, message, data } = opts
       if (!message || typeof message !== 'string') throw new Error(
         '"message" must be a nonempty string'
       )
-      return new EthJsonRpcError(code, message, data)
+      return new EthereumProviderError(code, message, data)
     },
   },
 }
 
 // Internal
 
-function getJsonRpcError(code, message, data) {
-  return new JsonRpcError(
+function getEthJsonRpcError(code, opts) {
+  const [ message, data ] = validateOpts(opts)
+  return new EthereumRpcError(
     code,
     message || getMessageFromCode(code),
     data
   )
 }
 
-function getEthJsonRpcError(code, message, data) {
-  return new EthJsonRpcError(
+function getEthProviderError(code, opts) {
+  const [ message, data ] = validateOpts(opts)
+  return new EthereumProviderError(
     code,
     message || getMessageFromCode(code),
     data
   )
+}
+
+function validateOpts (opts) {
+  let message, data
+  if (opts) {
+    if (typeof opts === 'string') {
+      message = opts
+    } else if (opts && typeof opts === 'object' && !Array.isArray(opts)) {
+      message = opts.message
+      data = opts.data
+    }
+  }
+  return [ message, data ]
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,9 +16,9 @@ const FALLBACK_ERROR = {
  * Gets the message for a given code, or a fallback message if the code has
  * no corresponding message.
  * 
- * @param {number} code - The integer error code.
- * @param {string} fallbackMessage - The fallback message.
- * @return {string} The corresponding message or the fallback message.
+ * @param {number} code - The integer error code
+ * @param {string} fallbackMessage - The fallback message
+ * @return {string} - The corresponding message or the fallback message
  */
 function getMessageFromCode(code, fallbackMessage = FALLBACK_MESSAGE) {
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,11 @@
 
 const errorValues = require('./errorValues.json')
-const FALLBACK_ERROR_CODE = require('./errorCodes.json').jsonRpc.internal
-const { JsonRpcError } = require('./classes')
+const FALLBACK_ERROR_CODE = require('./errorCodes.json').rpc.internal
+const { EthereumRpcError } = require('./classes')
 
 const JSON_RPC_SERVER_ERROR_MESSAGE = 'Unspecified server error.'
 
-const FALLBACK_MESSAGE = 'Unspecified error message. This is  bug, please report it.'
+const FALLBACK_MESSAGE = 'Unspecified error message. This is a bug, please report it.'
 
 const FALLBACK_ERROR = {
   code: FALLBACK_ERROR_CODE,
@@ -15,6 +15,7 @@ const FALLBACK_ERROR = {
 /**
  * Gets the message for a given code, or a fallback message if the code has
  * no corresponding message.
+ * 
  * @param {number} code - The integer error code.
  * @param {string} fallbackMessage - The fallback message.
  * @return {string} The corresponding message or the fallback message.
@@ -38,6 +39,7 @@ function getMessageFromCode(code, fallbackMessage = FALLBACK_MESSAGE) {
 /**
  * Returns whether the given code is valid.
  * A code is only valid if it has a message.
+ * 
  * @param {number} code - The code to check
  * @return {boolean} true if the code is valid, false otherwise.
  */
@@ -58,7 +60,7 @@ function isValidCode(code) {
 }
 
 /**
- * Serializes the given error to an ETH JSON RPC-compatible error object.
+ * Serializes the given error to an Ethereum JSON RPC-compatible error object.
  * Merely copies the given error's values if it is already compatible.
  * If the given error is not fully compatible, it will be preserved on the
  * returned object's data.originalError property.
@@ -81,7 +83,7 @@ function serializeError (error, fallbackError = FALLBACK_ERROR) {
     )
   }
 
-  if (typeof error === 'object' && error instanceof JsonRpcError) {
+  if (typeof error === 'object' && error instanceof EthereumRpcError) {
     return error.serialize()
   }
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -3,14 +3,14 @@ const test = require('tape')
 const dequal = require('fast-deep-equal')
 
 const {
-  errors: rpcErrors, JsonRpcError, EthJsonRpcError, ERROR_CODES
+  ethErrors, EthereumRpcError, EthereumProviderError, ERROR_CODES
 } = require('../')
 const getMessageFromCode = require('../src/utils').getMessageFromCode
-const jsonRpcCodes = ERROR_CODES.jsonRpc
-const ethJsonRpcCodes = ERROR_CODES.eth
+const rpcCodes = ERROR_CODES.rpc
+const providerCodes = ERROR_CODES.provider
 const serverErrorMessage = require('../src/utils').JSON_RPC_SERVER_ERROR_MESSAGE
 
-const jsonRpcCodeValues = Object.values(jsonRpcCodes)
+const rpcCodeValues = Object.values(rpcCodes)
 
 const dummyData = { foo: 'bar' }
 
@@ -18,54 +18,85 @@ const SERVER_ERROR_CODE = -32098
 const CUSTOM_ERROR_CODE = 1001
 const CUSTOM_ERROR_MESSAGE = 'foo'
 
+test('ensure exported object accepts a single string argument where appropriate', t => {
+  let err = ethErrors.rpc.invalidInput(CUSTOM_ERROR_MESSAGE)
+  t.ok(err.code === ERROR_CODES.rpc.invalidInput, 'code is as expected')
+  t.ok(err.message === CUSTOM_ERROR_MESSAGE, 'message is as expected')
+
+  err = ethErrors.provider.unauthorized(CUSTOM_ERROR_MESSAGE)
+  t.ok(err.code === ERROR_CODES.provider.unauthorized, 'code is as expected')
+  t.ok(err.message === CUSTOM_ERROR_MESSAGE, 'message is as expected')
+  t.end()
+})
+
+test('ensure exported does not accept single string argument for some errors', t => {
+  t.throws(() => {
+    ethErrors.rpc.server('bar')
+  }, 'RPC Server error throws')
+  t.throws(() => {
+    ethErrors.provider.custom('bar')
+  }, 'Provider custom error throws')
+  t.end()
+})
+
 // we just iterate over all keys on the errors object and call and check
 // each error in turn
 test('test exported object for correctness', t => {
 
-  t.comment('Begin: JSON RPC 2.0')
-  Object.keys(rpcErrors).forEach(k => {
-    if (k !== 'eth') {
-      if (k === 'server') {
-        validateError(
-          rpcErrors[k](SERVER_ERROR_CODE, null, { ...dummyData }),
-          k, dummyData, t
-        )
-      } else validateError(
-        rpcErrors[k](null, { ...dummyData }),
+  t.comment('Begin: Ethereum RPC')
+  Object.keys(ethErrors.rpc).forEach(k => {
+    if (k === 'server') {
+      validateError(
+        ethErrors.rpc[k]({
+          code: SERVER_ERROR_CODE,
+          message: null,
+          data: { ...dummyData }
+        }),
         k, dummyData, t
       )
-    }
+    } else validateError(
+      ethErrors.rpc[k]({
+        message: null,
+        data: { ...dummyData }
+      }),
+      k, dummyData, t
+    )
   })
-  t.comment('End: JSON RPC 2.0')
+  t.comment('End: Ethereum RPC')
 
-  t.comment('Begin: ETH JSON RPC')
-  Object.keys(rpcErrors.eth).forEach(k => {
+  t.comment('Begin: Ethereum Provider')
+  Object.keys(ethErrors.provider).forEach(k => {
     if (k === 'custom') {
       validateError(
-        rpcErrors.eth[k](
-          CUSTOM_ERROR_CODE, CUSTOM_ERROR_MESSAGE, { ...dummyData }
-        ),
+        ethErrors.provider[k]({
+          code: CUSTOM_ERROR_CODE,
+          message: CUSTOM_ERROR_MESSAGE,
+          data: { ...dummyData }
+        }),
         k, dummyData, t, true
       )
     } else {
       validateError(
-        rpcErrors.eth[k](null, { ...dummyData }),
+      ethErrors.provider[k]({
+        message: null,
+        data: { ...dummyData }
+      }),
         k, dummyData, t, true
       )
     }
   })
-  t.comment('End: ETH JSON RPC')
+  t.comment('End: Ethereum Provider')
   t.end()
 })
 
-function validateError(err, key, data, t, isEth = false) {
+function validateError(err, key, data, t, isProvider = false) {
 
   t.comment(`testing: ${key}`)
   t.ok(
     (
       err instanceof Error &&
-      err instanceof JsonRpcError &&
-      isEth ? err instanceof EthJsonRpcError : true
+      err instanceof EthereumRpcError &&
+      isProvider ? err instanceof EthereumProviderError : true
     ),
     'error has correct inheritance'
   )
@@ -73,7 +104,7 @@ function validateError(err, key, data, t, isEth = false) {
   t.ok(err.message && typeof err.message === 'string', 'message is a string')
   t.ok(dequal(err.data, data), 'data is as provided')
 
-  if (err instanceof EthJsonRpcError) {
+  if (err instanceof EthereumProviderError) {
     t.ok(err.code >= 1000 && err.code < 5000, 'code has valid value')
 
     if (key === 'custom') {
@@ -84,15 +115,15 @@ function validateError(err, key, data, t, isEth = false) {
       )
     } else {
       t.ok(
-        err.code === ethJsonRpcCodes[key] &&
-        err.message === getMessageFromCode(ethJsonRpcCodes[key]),
+        err.code === providerCodes[key] &&
+        err.message === getMessageFromCode(providerCodes[key]),
         'code and message values correspond for error type'
       )
     }
-  } else if (err instanceof JsonRpcError) {
+  } else if (err instanceof EthereumRpcError) {
 
     t.ok(
-      jsonRpcCodeValues.includes(err.code) ||
+      rpcCodeValues.includes(err.code) ||
       err.code <= -32000 && err.code >= -32099,
       'code has valid value'
     )
@@ -105,8 +136,8 @@ function validateError(err, key, data, t, isEth = false) {
       )
     } else {
       t.ok(
-        err.code === jsonRpcCodes[key] &&
-        err.message === getMessageFromCode(jsonRpcCodes[key]),
+        err.code === rpcCodes[key] &&
+        err.message === getMessageFromCode(rpcCodes[key]),
         'code and message values correspond for error type'
       )
     }

--- a/test/errors.js
+++ b/test/errors.js
@@ -29,13 +29,63 @@ test('ensure exported object accepts a single string argument where appropriate'
   t.end()
 })
 
-test('ensure exported does not accept single string argument for some errors', t => {
-  t.throws(() => {
-    ethErrors.rpc.server('bar')
-  }, 'RPC Server error throws')
-  t.throws(() => {
-    ethErrors.provider.custom('bar')
-  }, 'Provider custom error throws')
+test('custom provider error options', t => {
+  t.throws(
+    () => {
+      ethErrors.provider.custom('bar')
+    },
+    /Ethereum Provider custom errors must/,
+    'does not accept non-object argument'
+  )
+
+  t.throws(
+    () => {
+      ethErrors.provider.custom({ code: 4009, message: 2 })
+    },
+    /"message" must be/,
+    'does not accept nonstring message'
+  )
+
+  t.throws(
+    () => {
+      ethErrors.provider.custom({ code: 4009, message: '' })
+    },
+    /"message" must be/,
+    'does not accept empty message'
+  )
+
+  const err = ethErrors.provider.custom({ code: 4009, message: 'foo' })
+  t.ok(err instanceof EthereumProviderError)
+  t.end()
+})
+
+test('server rpc error options', t => {
+  t.throws(
+    () => {
+      ethErrors.rpc.server('bar')
+    },
+    /Ethereum RPC Server errors must/,
+    'does not accept non-object argument'
+  )
+
+  t.throws(
+    () => {
+      ethErrors.rpc.server({ code: 'bar'})
+    },
+    /"code" must be/,
+    'does not accept non-string code'
+  )
+
+  t.throws(
+    () => {
+      ethErrors.rpc.server({ code: 1})
+    },
+    /"code" must be/,
+    'does not accept out-of-range code'
+  )
+
+  const err = ethErrors.rpc.server({ code: -32006, message: 'foo' })
+  t.ok(err instanceof EthereumRpcError)
   t.end()
 })
 

--- a/test/serializeError.js
+++ b/test/serializeError.js
@@ -2,10 +2,10 @@
 const test = require('tape')
 const dequal = require('fast-deep-equal')
 
-const { errors: rpcErrors, serializeError, ERROR_CODES } = require('../')
+const { ethErrors, serializeError, ERROR_CODES } = require('../')
 const getMessageFromCode = require('../src/utils').getMessageFromCode
 
-const jsonRpcCodes = ERROR_CODES.jsonRpc
+const rpcCodes = ERROR_CODES.rpc
 
 const dummyData = { foo: 'bar' }
 const dummyMessage = 'baz'
@@ -21,8 +21,12 @@ const invalidError7 = { code: 34, message: dummyMessage , data: { ...dummyData }
 
 const validError0 = { code: 4001, message: dummyMessage }
 const validError1 = { code: 4001, message: dummyMessage, data: { ...dummyData } }
-const validError2 = rpcErrors.parse()
-const validError3 = rpcErrors.parse(dummyMessage, { ...dummyData })
+const validError2 = ethErrors.rpc.parse()
+const validError3 = ethErrors.rpc.parse(dummyMessage)
+const validError4 = ethErrors.rpc.parse({
+  message: dummyMessage,
+  data: { ...dummyData }
+})
 
 test('invalid error: non-object', t => {
   const result = serializeError(invalidError0)
@@ -30,8 +34,8 @@ test('invalid error: non-object', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
-        message: getMessageFromCode(jsonRpcCodes.internal),
+        code: rpcCodes.internal,
+        message: getMessageFromCode(rpcCodes.internal),
         data: { originalError: invalidError0 }
       }
     ),
@@ -46,8 +50,8 @@ test('invalid error: null', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
-        message: getMessageFromCode(jsonRpcCodes.internal),
+        code: rpcCodes.internal,
+        message: getMessageFromCode(rpcCodes.internal),
         data: { originalError: invalidError5 }
       }
     ),
@@ -62,8 +66,8 @@ test('invalid error: undefined', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
-        message: getMessageFromCode(jsonRpcCodes.internal),
+        code: rpcCodes.internal,
+        message: getMessageFromCode(rpcCodes.internal),
         data: { originalError: invalidError6 }
       }
     ),
@@ -78,8 +82,8 @@ test('invalid error: array', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
-        message: getMessageFromCode(jsonRpcCodes.internal),
+        code: rpcCodes.internal,
+        message: getMessageFromCode(rpcCodes.internal),
         data: { originalError: invalidError1 }
       }
     ),
@@ -94,8 +98,8 @@ test('invalid error: invalid code', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
-        message: getMessageFromCode(jsonRpcCodes.internal),
+        code: rpcCodes.internal,
+        message: getMessageFromCode(rpcCodes.internal),
         data: { originalError: { ...invalidError2 } }
       }
     ),
@@ -142,7 +146,7 @@ test('invalid error: invalid code with string message', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.internal,
+        code: rpcCodes.internal,
         message: dummyMessage,
         data: { originalError: { ...invalidError7 } }
       }
@@ -189,8 +193,8 @@ test('valid error: instantiated error', t => {
     dequal(
       result,
       {
-        code: jsonRpcCodes.parse,
-        message: getMessageFromCode(jsonRpcCodes.parse),
+        code: rpcCodes.parse,
+        message: getMessageFromCode(rpcCodes.parse),
         stack: validError2.stack,
       }
     ),
@@ -199,16 +203,32 @@ test('valid error: instantiated error', t => {
   t.end()
 })
 
-test('valid error: instantiated error with custom message and data', t => {
+test('valid error: instantiated error', t => {
   const result = serializeError(validError3)
   t.ok(
     dequal(
       result,
       {
-        code: jsonRpcCodes.parse,
-        message: validError3.message,
-        data: { ...validError3.data },
+        code: rpcCodes.parse,
+        message: dummyMessage,
         stack: validError3.stack,
+      }
+    ),
+    'serialized error matches expected result'
+  )
+  t.end()
+})
+
+test('valid error: instantiated error with custom message and data', t => {
+  const result = serializeError(validError4)
+  t.ok(
+    dequal(
+      result,
+      {
+        code: rpcCodes.parse,
+        message: validError4.message,
+        data: { ...validError4.data },
+        stack: validError4.stack,
       }
     ),
     'serialized error matches expected result'


### PR DESCRIPTION
* add EIP 1474 errors (see README)
* main errors API
    * rename main API object to `ethErrors`
    * change arg for all errors to `Object | string`
    * change API namespace, now `ethErrors.rpc` (EIP 1474 and JSON RPC 2.0) and `.provider` (EIP 1193) with no errors directly under `ethErrors`
* update types, docs, and tests