### PR TITLE
Fix faulty null checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-json-rpc-errors",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Ethereum JSON RPC and Provider errors.",
   "main": "index.js",
   "scripts": {

--- a/src/errors.js
+++ b/src/errors.js
@@ -77,7 +77,7 @@ module.exports = {
      * @returns {EthereumRpcError} The error
      */
     server: (opts) => {
-      if (typeof opts !== 'object' || Array.isArray(opts)) {
+      if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
         throw new Error('Ethereum RPC Server errors must provide single object argument.')
       }
       const { code } = opts
@@ -203,7 +203,7 @@ module.exports = {
      * @returns {EthereumProviderError} The error
      */
     custom: (opts) => {
-      if (typeof opts !== 'object' || Array.isArray(opts)) {
+      if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
         throw new Error('Ethereum Provider custom errors must provide single object argument.')
       }
       const { code, message, data } = opts
@@ -240,7 +240,7 @@ function validateOpts (opts) {
   if (opts) {
     if (typeof opts === 'string') {
       message = opts
-    } else if (opts && typeof opts === 'object' && !Array.isArray(opts)) {
+    } else if (typeof opts === 'object' && !Array.isArray(opts)) {
       message = opts.message
       data = opts.data
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,7 @@ function serializeError (error, fallbackError = FALLBACK_ERROR) {
     )
   }
 
-  if (typeof error === 'object' && error instanceof EthereumRpcError) {
+  if (error instanceof EthereumRpcError) {
     return error.serialize()
   }
 


### PR DESCRIPTION
- **Includes patch version bump**
- For typechecks of the form `/typeof .+ (===|!==) 'object'/`, adds a check if the tested variable is truthy or falsy as appropriate.