### PR TITLE
Stop serializing error stacks

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,6 @@ function isValidCode (code) {
  * Merely copies the given error's values if it is already compatible.
  * If the given error is not fully compatible, it will be preserved on the
  * returned object's data.originalError property.
- * Adds a 'stack' property if it exists on the given error.
  *
  * @param {any} error - The error to serialize.
  * @param {object} fallbackError - The custom fallback error values if the
@@ -119,9 +118,6 @@ function serializeError (error, fallbackError = FALLBACK_ERROR) {
     serialized.data = { originalError: assignOriginalError(error) }
   }
 
-  if (error && error.stack) {
-    serialized.stack = error.stack
-  }
   return serialized
 }
 

--- a/test/serializeError.js
+++ b/test/serializeError.js
@@ -22,11 +22,14 @@ const invalidError7 = { code: 34, message: dummyMessage, data: { ...dummyData } 
 const validError0 = { code: 4001, message: dummyMessage }
 const validError1 = { code: 4001, message: dummyMessage, data: { ...dummyData } }
 const validError2 = ethErrors.rpc.parse()
+delete validError2.stack
 const validError3 = ethErrors.rpc.parse(dummyMessage)
+delete validError3.stack
 const validError4 = ethErrors.rpc.parse({
   message: dummyMessage,
   data: { ...dummyData },
 })
+delete validError4.stack
 
 test('invalid error: non-object', (t) => {
   const result = serializeError(invalidError0)
@@ -195,7 +198,6 @@ test('valid error: instantiated error', (t) => {
       {
         code: rpcCodes.parse,
         message: getMessageFromCode(rpcCodes.parse),
-        stack: validError2.stack,
       },
     ),
     'serialized error matches expected result',
@@ -211,7 +213,6 @@ test('valid error: instantiated error', (t) => {
       {
         code: rpcCodes.parse,
         message: dummyMessage,
-        stack: validError3.stack,
       },
     ),
     'serialized error matches expected result',
@@ -228,7 +229,6 @@ test('valid error: instantiated error with custom message and data', (t) => {
         code: rpcCodes.parse,
         message: validError4.message,
         data: { ...validError4.data },
-        stack: validError4.stack,
       },
     ),
     'serialized error matches expected result',


### PR DESCRIPTION
The serialized error stack is emphatically _not_ useful to consumers in most circumstances, and we should do away with it.

The only situation in which the stack is useful is during development, and there's error logging for that.