### PR TITLE
Fix serialize error options type

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -28,7 +28,7 @@ export interface IProviderCustomErrorOptions extends IErrorOptions {
 
 interface SerializeErrorOptions {
   fallbackError?: object,
-  shouldSerializeStack?: boolean,
+  shouldIncludeStack?: boolean,
 }
 
 export interface ISerializeError {


### PR DESCRIPTION
Property in type was misnamed `shouldSerializeStack` instead of `shouldIncludeStack`.