### PR TITLE
Use @metamask/eslint-config@3.1.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,4 @@ module.exports = {
     '!.eslintrc.js',
     'node_modules/',
   ],
-  rules: {
-    'prefer-object-spread': 'off', // Requires ES2018
-  },
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fast-safe-stringify": "^2.0.6"
   },
   "devDependencies": {
-    "@metamask/eslint-config": "^2.1.1",
+    "@metamask/eslint-config": "^3.1.0",
     "eslint": "6.8.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-json": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,10 +192,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@metamask/eslint-config@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-2.1.1.tgz#df38ff2199783ac2e7726b17d140328d1cb595f9"
-  integrity sha512-DBixWzP6B5q00OPYXhRFg6GlR5ZxXWDOFeSa31I31GjZCEVY4NUwjSAT10UEaR7RncUI0WONXIC/P3P43UZx3w==
+"@metamask/eslint-config@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
+  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
This PR updates the `@metamask/eslint-config` dependency to the latest published version, v3.1.0.