### PR TITLE
Target ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "strict": true,
-    "target": "ES2015"
+    "target": "ES2017"
   },
   "include": [
     "./src/*.ts"


### PR DESCRIPTION
We target ES2017 for most of our other libraries, rather than ES2015. Among other things, this lets us avoid transpiling `async/await`, which is especially useful for debugging.