### PR TITLE
Robustify build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "Erik Marks <rekmarks@protonmail.com>",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project .",
     "test": "yarn build && node test",
     "test:coverage": "yarn build && nyc tape test",
     "lint": "eslint . --ext ts,js,json",


### PR DESCRIPTION
This PR ensures that we prevent kooky stuff from happening by making the build script more specific.

Ref: https://www.typescriptlang.org/docs/handbook/compiler-options.html