### PR TITLE
Fix typing of error data and stack properties

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -4,7 +4,7 @@ export interface SerializedEthereumRpcError {
   code: number; // must be an integer
   message: string;
   data?: unknown;
-  stack?: unknown;
+  stack?: string;
 }
 
 /**

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -16,7 +16,7 @@ export class EthereumRpcError<T> extends Error {
 
   public code: number;
 
-  public data: T | undefined;
+  public data?: T;
 
   constructor(code: number, message: string, data?: T) {
 
@@ -76,7 +76,7 @@ export class EthereumProviderError<T> extends EthereumRpcError<T> {
 
   /**
    * Create an Ethereum Provider JSON-RPC error.
-   * `code` must be an integer in the [ 1000 <= 4999 ] range.
+   * `code` must be an integer in the 1000 <= 4999 range.
    */
   constructor(code: number, message: string, data?: T) {
 


### PR DESCRIPTION
If `stack` is present, it will be a string. This PR updates the `SerializedEthereumRpcError` interface to reflect this. Also fixes a couple of minor docstring / type errors.