### PR TITLE
Rewrite error serialization

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.25,
+      branches: 94.44,
       functions: 85,
-      lines: 96.85,
-      statements: 96.85,
+      lines: 96.87,
+      statements: 96.87,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 91.66,
-      functions: 84.21,
-      lines: 95.83,
-      statements: 95.83,
+      branches: 92.3,
+      functions: 85,
+      lines: 96.04,
+      statements: 96.04,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 92.3,
-      functions: 85,
-      lines: 96.04,
-      statements: 96.04,
+      branches: 93.58,
+      functions: 84.61,
+      lines: 96.71,
+      statements: 96.71,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,7 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.31,
+      branches: 94.25,
       functions: 85,
       lines: 96.85,
       statements: 96.85,

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90.09,
+      branches: 91.66,
       functions: 84.21,
-      lines: 95.32,
-      statements: 95.32,
+      lines: 95.83,
+      statements: 95.83,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.58,
-      functions: 84.61,
-      lines: 96.71,
-      statements: 96.71,
+      branches: 94.31,
+      functions: 85,
+      lines: 96.85,
+      statements: 96.85,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^3.3.0",
-    "fast-safe-stringify": "^2.0.6",
-    "superstruct": "^0.16.7"
+    "@metamask/utils": "^5.0.0",
+    "fast-safe-stringify": "^2.0.6"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier-plugin-packagejson": "^2.2.18",
     "ts-jest": "^28.0.7",
     "typedoc": "^0.23.19",
-    "typescript": "~4.7.4"
+    "typescript": "~4.9.5"
   },
   "packageManager": "yarn@3.2.4",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@metamask/utils": "^3.2.0",
-    "fast-safe-stringify": "^2.0.6"
+    "fast-safe-stringify": "^2.0.6",
+    "superstruct": "^0.16.6"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/utils": "^3.2.0",
+    "@metamask/utils": "^3.3.0",
     "fast-safe-stringify": "^2.0.6",
-    "superstruct": "^0.16.6"
+    "superstruct": "^0.16.7"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",

--- a/src/__fixtures__/errors.ts
+++ b/src/__fixtures__/errors.ts
@@ -5,7 +5,7 @@ export const dummyMessage = 'baz';
 
 export const invalidError0 = 0;
 export const invalidError1 = ['foo', 'bar', 3];
-export const invalidError2 = { code: 34 };
+export const invalidError2 = { code: 'foo' };
 export const invalidError3 = { code: 4001 };
 export const invalidError4 = {
   code: 4001,
@@ -15,7 +15,7 @@ export const invalidError4 = {
 export const invalidError5 = null;
 export const invalidError6 = undefined;
 export const invalidError7 = {
-  code: 34,
+  code: 'foo',
   message: dummyMessage,
   data: Object.assign({}, dummyData),
 };

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -1,12 +1,7 @@
 import safeStringify from 'fast-safe-stringify';
-import { Json } from '@metamask/utils';
+import { Json, JsonRpcError } from '@metamask/utils';
 
-export type SerializedEthereumRpcError = {
-  code: number;
-  message: string;
-  data?: Json;
-  stack?: string;
-};
+export { JsonRpcError };
 
 /**
  * Error subclass implementing JSON RPC 2.0 errors and Ethereum RPC errors
@@ -40,8 +35,8 @@ export class EthereumRpcError<T extends Json> extends Error {
    *
    * @returns A plain object with all public class properties.
    */
-  serialize(): SerializedEthereumRpcError {
-    const serialized: SerializedEthereumRpcError = {
+  serialize(): JsonRpcError {
+    const serialized: JsonRpcError = {
       code: this.code,
       message: this.message,
     };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -191,4 +191,12 @@ describe('serializeError', () => {
       data: Object.assign({}, validError1.data),
     });
   });
+
+  it('handles regular Error()', () => {
+    const result = serializeError(new Error('foo'));
+    expect(result).toStrictEqual({
+      code: errorCodes.rpc.internal,
+      message: 'foo',
+    });
+  });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -44,7 +44,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { cause: invalidError6 },
+      data: { cause: null },
     });
   });
 
@@ -269,5 +269,25 @@ describe('serializeError', () => {
     ).toThrow(
       'Must provide fallback error with integer number code and string message.',
     );
+  });
+
+  it('handles arrays passed as error', () => {
+    const error = ['foo', Symbol('bar'), { baz: 'qux', symbol: Symbol('') }];
+    const result = serializeError(error);
+    expect(result).toStrictEqual({
+      code: rpcCodes.internal,
+      message: getMessageFromCode(rpcCodes.internal),
+      data: {
+        cause: ['foo', null, { baz: 'qux' }],
+      },
+    });
+
+    expect(JSON.parse(JSON.stringify(result))).toStrictEqual({
+      code: rpcCodes.internal,
+      message: getMessageFromCode(rpcCodes.internal),
+      data: {
+        cause: ['foo', null, { baz: 'qux' }],
+      },
+    });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -246,6 +246,25 @@ describe('serializeError', () => {
     });
   });
 
+  it('handles class that has serialize function', () => {
+    class MockClass {
+      serialize() {
+        return { code: 1, message: 'foo' };
+      }
+    }
+    const error = new MockClass();
+    const result = serializeError(error);
+    expect(result).toStrictEqual({
+      code: 1,
+      message: 'foo',
+    });
+
+    expect(JSON.parse(JSON.stringify(result))).toStrictEqual({
+      code: 1,
+      message: 'foo',
+    });
+  });
+
   it('removes non JSON-serializable props on cause', () => {
     const error = new Error('foo');
     // @ts-expect-error Intentionally using wrong type

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -25,7 +25,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { originalError: invalidError0 },
+      data: { cause: invalidError0 },
     });
   });
 
@@ -34,7 +34,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { originalError: invalidError5 },
+      data: { cause: invalidError5 },
     });
   });
 
@@ -43,7 +43,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { originalError: invalidError6 },
+      data: { cause: invalidError6 },
     });
   });
 
@@ -52,7 +52,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { originalError: invalidError1 },
+      data: { cause: invalidError1 },
     });
   });
 
@@ -61,7 +61,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: getMessageFromCode(rpcCodes.internal),
-      data: { originalError: invalidError2 },
+      data: { cause: invalidError2 },
     });
   });
 
@@ -70,7 +70,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: 4001,
       message: getMessageFromCode(4001),
-      data: { originalError: Object.assign({}, invalidError3) },
+      data: { cause: Object.assign({}, invalidError3) },
     });
   });
 
@@ -79,7 +79,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: 4001,
       message: getMessageFromCode(4001),
-      data: { originalError: Object.assign({}, invalidError4) },
+      data: { cause: Object.assign({}, invalidError4) },
     });
   });
 
@@ -88,7 +88,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: dummyMessage,
-      data: { originalError: Object.assign({}, invalidError7) },
+      data: { cause: Object.assign({}, invalidError7) },
     });
   });
 
@@ -99,7 +99,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.methodNotFound,
       message: 'foo',
-      data: { originalError: Object.assign({}, invalidError2) },
+      data: { cause: Object.assign({}, invalidError2) },
     });
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -13,6 +13,7 @@ import {
   validError3,
   validError4,
   dummyMessage,
+  dummyData,
 } from './__fixtures__';
 import { getMessageFromCode, serializeError } from './utils';
 import { errorCodes } from '.';
@@ -70,7 +71,6 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: 4001,
       message: getMessageFromCode(4001),
-      data: { cause: Object.assign({}, invalidError3) },
     });
   });
 
@@ -79,7 +79,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: 4001,
       message: getMessageFromCode(4001),
-      data: { cause: Object.assign({}, invalidError4) },
+      data: Object.assign({}, dummyData),
     });
   });
 
@@ -88,7 +88,7 @@ describe('serializeError', () => {
     expect(result).toStrictEqual({
       code: rpcCodes.internal,
       message: dummyMessage,
-      data: { cause: Object.assign({}, invalidError7) },
+      data: Object.assign({}, dummyData),
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,7 @@ export function isValidCode(code: unknown): code is number {
  * @param error - The error to serialize.
  * @param options - Options bag.
  * @param options.fallbackError - The error to return if the given error is
- * not compatible.
+ * not compatible. Should be a JSON serializable value.
  * @param options.shouldIncludeStack - Whether to include the error's stack
  * on the returned object.
  * @returns The serialized error.
@@ -95,10 +95,10 @@ export function serializeError(
 }
 
 /**
- * Construct a JSON-serializable object given an error and a `fallbackError`
+ * Construct a JSON-serializable object given an error and a JSON serializable `fallbackError`
  *
  * @param error - The error in question.
- * @param fallbackError - The fallback error.
+ * @param fallbackError - A JSON serializable fallback error.
  * @returns A JSON serializable error object.
  */
 function buildError(error: unknown, fallbackError: JsonRpcError): JsonRpcError {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,10 +84,6 @@ export function serializeError(
     );
   }
 
-  if (error instanceof EthereumRpcError) {
-    return error.serialize();
-  }
-
   const serialized = buildError(error, fallbackError as JsonRpcError);
 
   if (!shouldIncludeStack) {
@@ -105,6 +101,10 @@ export function serializeError(
  * @returns A JSON serializable error object.
  */
 function buildError(error: unknown, fallbackError: JsonRpcError): JsonRpcError {
+  if (error instanceof EthereumRpcError) {
+    return error.serialize();
+  }
+
   if (isJsonRpcError(error)) {
     return error;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,9 @@ import {
   JsonRpcErrorStruct,
   isValidJson,
   isObject,
+  isJsonRpcError,
 } from '@metamask/utils';
-import { is, create } from 'superstruct';
+import { create } from 'superstruct';
 import { errorCodes, errorValues } from './error-constants';
 import { EthereumRpcError, SerializedEthereumRpcError } from './classes';
 
@@ -77,7 +78,7 @@ export function serializeError(
   error: unknown,
   { fallbackError = FALLBACK_ERROR, shouldIncludeStack = false } = {},
 ): SerializedEthereumRpcError {
-  if (!is(fallbackError, JsonRpcErrorStruct)) {
+  if (!isJsonRpcError(fallbackError)) {
     throw new Error(
       'Must provide fallback error with integer number code and string message.',
     );
@@ -107,7 +108,7 @@ export function serializeError(
  * @returns A JSON serializable error object.
  */
 function buildError(error: unknown, fallbackError: SerializedEthereumRpcError) {
-  if (is(error, JsonRpcErrorStruct)) {
+  if (isJsonRpcError(error)) {
     return create(error, JsonRpcErrorStruct);
   }
   // If the original error is an object, we make a copy of it, this should also copy class properties to an object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,15 +164,15 @@ function serializeCause(error: unknown): Json {
  * @returns An object containing all the JSON-serializable properties.
  */
 function serializeObject(object: RuntimeObject): Json {
-  return Object.getOwnPropertyNames(object).reduce((acc, key) => {
-    const value = object[key];
-    if (isValidJson(value)) {
-      return {
-        ...acc,
-        [key]: value,
-      };
-    }
+  return Object.getOwnPropertyNames(object).reduce<Record<string, Json>>(
+    (acc, key) => {
+      const value = object[key];
+      if (isValidJson(value)) {
+        acc[key] = value;
+      }
 
-    return acc;
-  }, {});
+      return acc;
+    },
+    {},
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,7 +1244,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.18
     ts-jest: ^28.0.7
     typedoc: ^0.23.19
-    typescript: ~4.7.4
+    typescript: ~4.9.5
   languageName: unknown
   linkType: soft
 
@@ -6292,23 +6292,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.7.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:~4.9.5":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=701156"
+"typescript@patch:typescript@~4.9.5#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=701156"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
+  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,7 +894,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
-    "@metamask/utils": ^3.2.0
+    "@metamask/utils": ^3.3.0
     "@types/jest": ^28.1.6
     "@typescript-eslint/eslint-plugin": ^5.33.1
     "@typescript-eslint/parser": ^5.33.1
@@ -911,22 +911,21 @@ __metadata:
     jest-it-up: ^2.0.2
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.18
-    superstruct: ^0.16.6
+    superstruct: ^0.16.7
     ts-jest: ^28.0.7
     typedoc: ^0.23.19
     typescript: ~4.7.4
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@metamask/utils@npm:3.2.0"
+"@metamask/utils@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@metamask/utils@npm:3.3.0"
   dependencies:
     "@types/debug": ^4.1.7
     debug: ^4.3.4
-    fast-deep-equal: ^3.1.3
-    superstruct: ^0.16.5
-  checksum: 99adcbd273c69075628913259f8c3fb843291898eba813f4f5fe0bfc060ae5955e2c69e70e15b04156793f8d84edd077d1fac3f8c3927e067d0f311eef9d4469
+    superstruct: ^0.16.7
+  checksum: 263c26722b7339fced997cc2aa38ccb34d178f532ff025c7e789818ad5ef2317439eda694a4c0bf5ff3cabdeced3c170b9ad23d2f178ddd5fd225f6ec2bce259
   languageName: node
   linkType: hard
 
@@ -5555,7 +5554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superstruct@npm:^0.16.5, superstruct@npm:^0.16.6":
+"superstruct@npm:^0.16.7":
   version: 0.16.7
   resolution: "superstruct@npm:0.16.7"
   checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,6 +911,7 @@ __metadata:
     jest-it-up: ^2.0.2
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.18
+    superstruct: ^0.16.6
     ts-jest: ^28.0.7
     typedoc: ^0.23.19
     typescript: ~4.7.4
@@ -5554,7 +5555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superstruct@npm:^0.16.5":
+"superstruct@npm:^0.16.5, superstruct@npm:^0.16.6":
   version: 0.16.7
   resolution: "superstruct@npm:0.16.7"
   checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,6 +397,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainsafe/as-sha256@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@chainsafe/as-sha256@npm:0.3.1"
+  checksum: 58ea733be1657b0e31dbf48b0dba862da0833df34a81c1460c7352f04ce90874f70003cbf34d0afb9e5e53a33ee2d63a261a8b12462be85b2ba0a6f7f13d6150
+  languageName: node
+  linkType: hard
+
+"@chainsafe/persistent-merkle-tree@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "@chainsafe/persistent-merkle-tree@npm:0.4.2"
+  dependencies:
+    "@chainsafe/as-sha256": ^0.3.1
+  checksum: f9cfcb2132a243992709715dbd28186ab48c7c0c696f29d30857693cca5526bf753974a505ef68ffd5623bbdbcaa10f9083f4dd40bf99eb6408e451cc26a1a9e
+  languageName: node
+  linkType: hard
+
+"@chainsafe/ssz@npm:0.9.4":
+  version: 0.9.4
+  resolution: "@chainsafe/ssz@npm:0.9.4"
+  dependencies:
+    "@chainsafe/as-sha256": ^0.3.1
+    "@chainsafe/persistent-merkle-tree": ^0.4.2
+    case: ^1.6.3
+  checksum: c6eaedeae9e5618b3c666ff4507a27647f665a8dcf17d5ca86da4ed4788c5a93868f256d0005467d184fdf35ec03f323517ec2e55ec42492d769540a2ec396bc
+  languageName: node
+  linkType: hard
+
 "@es-joy/jsdoccomment@npm:~0.33.4":
   version: 0.33.4
   resolution: "@es-joy/jsdoccomment@npm:0.33.4"
@@ -422,6 +449,310 @@ __metadata:
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
   checksum: f03e9d6727efd3e0719da2051ea80c0c73d20e28c171121527dbb868cd34232ca9c1d0525a66e517a404afea26624b1e47895b6a92474678418c2f50c9566694
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/common@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@ethereumjs/common@npm:3.1.1"
+  dependencies:
+    "@ethereumjs/util": ^8.0.5
+    crc-32: ^1.2.0
+  checksum: 58602dee9fbcf691dca111b4fd7fd5770f5e86d68012ce48fba396c7038afdca4fca273a9cf39f88cf6ea7b256603a4bd214e94e9d01361efbcd060460b78952
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/rlp@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@ethereumjs/rlp@npm:4.0.1"
+  bin:
+    rlp: bin/rlp
+  checksum: 30db19c78faa2b6ff27275ab767646929207bb207f903f09eb3e4c273ce2738b45f3c82169ddacd67468b4f063d8d96035f2bf36f02b6b7e4d928eefe2e3ecbc
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/tx@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@ethereumjs/tx@npm:4.1.1"
+  dependencies:
+    "@chainsafe/ssz": 0.9.4
+    "@ethereumjs/common": ^3.1.1
+    "@ethereumjs/rlp": ^4.0.1
+    "@ethereumjs/util": ^8.0.5
+    "@ethersproject/providers": ^5.7.2
+    ethereum-cryptography: ^1.1.2
+  peerDependencies:
+    c-kzg: ^1.0.8
+  peerDependenciesMeta:
+    c-kzg:
+      optional: true
+  checksum: 98897e79adf03ee90ed98c6a543e15e0b4e127bc5bc381d70cdcc76b111574205b94869c29d925ea9e30a98e5ef8b0f5597914359deb9db552017b2e78ef17a8
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/util@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "@ethereumjs/util@npm:8.0.5"
+  dependencies:
+    "@chainsafe/ssz": 0.9.4
+    "@ethereumjs/rlp": ^4.0.1
+    ethereum-cryptography: ^1.1.2
+  checksum: 318386785295b4584289b1aa576d2621392b3a918d127890db62d3f74184f3377694dd9e951e19bfb9ab80e8dc9e38e180236cac2651dead26097d10963731f9
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abstract-provider@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/abstract-provider@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/networks": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/transactions": ^5.7.0
+    "@ethersproject/web": ^5.7.0
+  checksum: 74cf4696245cf03bb7cc5b6cbf7b4b89dd9a79a1c4688126d214153a938126d4972d42c93182198653ce1de35f2a2cad68be40337d4774b3698a39b28f0228a8
+  languageName: node
+  linkType: hard
+
+"@ethersproject/abstract-signer@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/abstract-signer@npm:5.7.0"
+  dependencies:
+    "@ethersproject/abstract-provider": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+  checksum: a823dac9cfb761e009851050ebebd5b229d1b1cc4a75b125c2da130ff37e8218208f7f9d1386f77407705b889b23d4a230ad67185f8872f083143e0073cbfbe3
+  languageName: node
+  linkType: hard
+
+"@ethersproject/address@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/address@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/rlp": ^5.7.0
+  checksum: 64ea5ebea9cc0e845c413e6cb1e54e157dd9fc0dffb98e239d3a3efc8177f2ff798cd4e3206cf3660ee8faeb7bef1a47dc0ebef0d7b132c32e61e550c7d4c843
+  languageName: node
+  linkType: hard
+
+"@ethersproject/base64@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/base64@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+  checksum: 7dd5d734d623582f08f665434f53685041a3d3b334a0e96c0c8afa8bbcaab934d50e5b6b980e826a8fde8d353e0b18f11e61faf17468177274b8e7c69cd9742b
+  languageName: node
+  linkType: hard
+
+"@ethersproject/basex@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/basex@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+  checksum: 326087b7e1f3787b5fe6cd1cf2b4b5abfafbc355a45e88e22e5e9d6c845b613ffc5301d629b28d5c4d5e2bfe9ec424e6782c804956dff79be05f0098cb5817de
+  languageName: node
+  linkType: hard
+
+"@ethersproject/bignumber@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/bignumber@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    bn.js: ^5.2.1
+  checksum: 8c9a134b76f3feb4ec26a5a27379efb4e156b8fb2de0678a67788a91c7f4e30abe9d948638458e4b20f2e42380da0adacc7c9389d05fce070692edc6ae9b4904
+  languageName: node
+  linkType: hard
+
+"@ethersproject/bytes@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/bytes@npm:5.7.0"
+  dependencies:
+    "@ethersproject/logger": ^5.7.0
+  checksum: 66ad365ceaab5da1b23b72225c71dce472cf37737af5118181fa8ab7447d696bea15ca22e3a0e8836fdd8cfac161afe321a7c67d0dde96f9f645ddd759676621
+  languageName: node
+  linkType: hard
+
+"@ethersproject/constants@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/constants@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bignumber": ^5.7.0
+  checksum: 6d4b1355747cce837b3e76ec3bde70e4732736f23b04f196f706ebfa5d4d9c2be50904a390d4d40ce77803b98d03d16a9b6898418e04ba63491933ce08c4ba8a
+  languageName: node
+  linkType: hard
+
+"@ethersproject/hash@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/hash@npm:5.7.0"
+  dependencies:
+    "@ethersproject/abstract-signer": ^5.7.0
+    "@ethersproject/address": ^5.7.0
+    "@ethersproject/base64": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/strings": ^5.7.0
+  checksum: 6e9fa8d14eb08171cd32f17f98cc108ec2aeca74a427655f0d689c550fee0b22a83b3b400fad7fb3f41cf14d4111f87f170aa7905bcbcd1173a55f21b06262ef
+  languageName: node
+  linkType: hard
+
+"@ethersproject/keccak256@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/keccak256@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    js-sha3: 0.8.0
+  checksum: ff70950d82203aab29ccda2553422cbac2e7a0c15c986bd20a69b13606ed8bb6e4fdd7b67b8d3b27d4f841e8222cbaccd33ed34be29f866fec7308f96ed244c6
+  languageName: node
+  linkType: hard
+
+"@ethersproject/logger@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/logger@npm:5.7.0"
+  checksum: 075ab2f605f1fd0813f2e39c3308f77b44a67732b36e712d9bc085f22a84aac4da4f71b39bee50fe78da3e1c812673fadc41180c9970fe5e486e91ea17befe0d
+  languageName: node
+  linkType: hard
+
+"@ethersproject/networks@npm:^5.7.0":
+  version: 5.7.1
+  resolution: "@ethersproject/networks@npm:5.7.1"
+  dependencies:
+    "@ethersproject/logger": ^5.7.0
+  checksum: 0339f312304c17d9a0adce550edb825d4d2c8c9468c1634c44172c67a9ed256f594da62c4cda5c3837a0f28b7fabc03aca9b492f68ff1fdad337ee861b27bd5d
+  languageName: node
+  linkType: hard
+
+"@ethersproject/properties@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/properties@npm:5.7.0"
+  dependencies:
+    "@ethersproject/logger": ^5.7.0
+  checksum: 6ab0ccf0c3aadc9221e0cdc5306ce6cd0df7f89f77d77bccdd1277182c9ead0202cd7521329ba3acde130820bf8af299e17cf567d0d497c736ee918207bbf59f
+  languageName: node
+  linkType: hard
+
+"@ethersproject/providers@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "@ethersproject/providers@npm:5.7.2"
+  dependencies:
+    "@ethersproject/abstract-provider": ^5.7.0
+    "@ethersproject/abstract-signer": ^5.7.0
+    "@ethersproject/address": ^5.7.0
+    "@ethersproject/base64": ^5.7.0
+    "@ethersproject/basex": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/constants": ^5.7.0
+    "@ethersproject/hash": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/networks": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/random": ^5.7.0
+    "@ethersproject/rlp": ^5.7.0
+    "@ethersproject/sha2": ^5.7.0
+    "@ethersproject/strings": ^5.7.0
+    "@ethersproject/transactions": ^5.7.0
+    "@ethersproject/web": ^5.7.0
+    bech32: 1.1.4
+    ws: 7.4.6
+  checksum: 1754c731a5ca6782ae9677f4a9cd8b6246c4ef21a966c9a01b133750f3c578431ec43ec254e699969c4a0f87e84463ded50f96b415600aabd37d2056aee58c19
+  languageName: node
+  linkType: hard
+
+"@ethersproject/random@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/random@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+  checksum: 017829c91cff6c76470852855108115b0b52c611b6be817ed1948d56ba42d6677803ec2012aa5ae298a7660024156a64c11fcf544e235e239ab3f89f0fff7345
+  languageName: node
+  linkType: hard
+
+"@ethersproject/rlp@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/rlp@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+  checksum: bce165b0f7e68e4d091c9d3cf47b247cac33252df77a095ca4281d32d5eeaaa3695d9bc06b2b057c5015353a68df89f13a4a54a72e888e4beeabbe56b15dda6e
+  languageName: node
+  linkType: hard
+
+"@ethersproject/sha2@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/sha2@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    hash.js: 1.1.7
+  checksum: 09321057c022effbff4cc2d9b9558228690b5dd916329d75c4b1ffe32ba3d24b480a367a7cc92d0f0c0b1c896814d03351ae4630e2f1f7160be2bcfbde435dbc
+  languageName: node
+  linkType: hard
+
+"@ethersproject/signing-key@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/signing-key@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    bn.js: ^5.2.1
+    elliptic: 6.5.4
+    hash.js: 1.1.7
+  checksum: 8f8de09b0aac709683bbb49339bc0a4cd2f95598f3546436c65d6f3c3a847ffa98e06d35e9ed2b17d8030bd2f02db9b7bd2e11c5cf8a71aad4537487ab4cf03a
+  languageName: node
+  linkType: hard
+
+"@ethersproject/strings@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/strings@npm:5.7.0"
+  dependencies:
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/constants": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+  checksum: 5ff78693ae3fdf3cf23e1f6dc047a61e44c8197d2408c42719fef8cb7b7b3613a4eec88ac0ed1f9f5558c74fe0de7ae3195a29ca91a239c74b9f444d8e8b50df
+  languageName: node
+  linkType: hard
+
+"@ethersproject/transactions@npm:^5.7.0":
+  version: 5.7.0
+  resolution: "@ethersproject/transactions@npm:5.7.0"
+  dependencies:
+    "@ethersproject/address": ^5.7.0
+    "@ethersproject/bignumber": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/constants": ^5.7.0
+    "@ethersproject/keccak256": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/rlp": ^5.7.0
+    "@ethersproject/signing-key": ^5.7.0
+  checksum: a31b71996d2b283f68486241bff0d3ea3f1ba0e8f1322a8fffc239ccc4f4a7eb2ea9994b8fd2f093283fd75f87bae68171e01b6265261f821369aca319884a79
+  languageName: node
+  linkType: hard
+
+"@ethersproject/web@npm:^5.7.0":
+  version: 5.7.1
+  resolution: "@ethersproject/web@npm:5.7.1"
+  dependencies:
+    "@ethersproject/base64": ^5.7.0
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/properties": ^5.7.0
+    "@ethersproject/strings": ^5.7.0
+  checksum: 7028c47103f82fd2e2c197ce0eecfacaa9180ffeec7de7845b1f4f9b19d84081b7a48227aaddde05a4aaa526af574a9a0ce01cc0fc75e3e371f84b38b5b16b2b
   languageName: node
   linkType: hard
 
@@ -894,7 +1225,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^10.0.0
     "@metamask/eslint-config-nodejs": ^10.0.0
     "@metamask/eslint-config-typescript": ^10.0.0
-    "@metamask/utils": ^3.3.0
+    "@metamask/utils": ^5.0.0
     "@types/jest": ^28.1.6
     "@typescript-eslint/eslint-plugin": ^5.33.1
     "@typescript-eslint/parser": ^5.33.1
@@ -911,21 +1242,36 @@ __metadata:
     jest-it-up: ^2.0.2
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.2.18
-    superstruct: ^0.16.7
     ts-jest: ^28.0.7
     typedoc: ^0.23.19
     typescript: ~4.7.4
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@metamask/utils@npm:3.3.0"
+"@metamask/utils@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@metamask/utils@npm:5.0.0"
   dependencies:
+    "@ethereumjs/tx": ^4.1.1
     "@types/debug": ^4.1.7
     debug: ^4.3.4
-    superstruct: ^0.16.7
-  checksum: 263c26722b7339fced997cc2aa38ccb34d178f532ff025c7e789818ad5ef2317439eda694a4c0bf5ff3cabdeced3c170b9ad23d2f178ddd5fd225f6ec2bce259
+    semver: ^7.3.8
+    superstruct: ^1.0.3
+  checksum: 34e39fc0bf28db5fe92676753de3291b05a517f8c81dbe332a4b6002739a58450a89fb2bddd85922a4f420affb1674604e6ad4627cdf052459e5371361ef7dd2
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.2.0, @noble/hashes@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "@noble/hashes@npm:1.2.0"
+  checksum: 8ca080ce557b8f40fb2f78d3aedffd95825a415ac8e13d7ffe3643f8626a8c2d99a3e5975b555027ac24316d8b3c02a35b8358567c0c23af681e6573602aa434
+  languageName: node
+  linkType: hard
+
+"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:~1.7.0":
+  version: 1.7.1
+  resolution: "@noble/secp256k1@npm:1.7.1"
+  checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
   languageName: node
   linkType: hard
 
@@ -1001,6 +1347,34 @@ __metadata:
     node-gyp: ^7.1.0
     read-package-json-fast: ^2.0.1
   checksum: 41924e7925452ac8e78d78bef5d65b3d58f86eea4481a453e11e3a9099504bfbfcf1f65d7f75d92170b846fa347d05424e58e617fb9c17b3efd87db599a0f46e
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.1.0":
+  version: 1.1.1
+  resolution: "@scure/base@npm:1.1.1"
+  checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@scure/bip32@npm:1.1.5"
+  dependencies:
+    "@noble/hashes": ~1.2.0
+    "@noble/secp256k1": ~1.7.0
+    "@scure/base": ~1.1.0
+  checksum: b08494ab0d2b1efee7226d1b5100db5157ebea22a78bb87126982a76a186cb3048413e8be0ba2622d00d048a20acbba527af730de86c132a77de616eb9907a3b
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@scure/bip39@npm:1.1.1"
+  dependencies:
+    "@noble/hashes": ~1.2.0
+    "@scure/base": ~1.1.0
+  checksum: fbb594c50696fa9c14e891d872f382e50a3f919b6c96c55ef2fb10c7102c546dafb8f099a62bd114c12a00525b595dcf7381846f383f0ddcedeaa6e210747d2f
   languageName: node
   linkType: hard
 
@@ -1675,6 +2049,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bech32@npm:1.1.4":
+  version: 1.1.4
+  resolution: "bech32@npm:1.1.4"
+  checksum: 0e98db619191548390d6f09ff68b0253ba7ae6a55db93dfdbb070ba234c1fd3308c0606fbcc95fad50437227b10011e2698b89f0181f6e7f845c499bd14d0f4b
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^4.11.9":
+  version: 4.12.0
+  resolution: "bn.js@npm:4.12.0"
+  checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "bn.js@npm:5.2.1"
+  checksum: 3dd8c8d38055fedfa95c1d5fc3c99f8dd547b36287b37768db0abab3c239711f88ff58d18d155dd8ad902b0b0cee973747b7ae20ea12a09473272b0201c9edd3
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -1700,6 +2095,13 @@ __metadata:
   dependencies:
     fill-range: ^7.0.1
   checksum: e2a8e769a863f3d4ee887b5fe21f63193a891c68b612ddb4b68d82d1b5f3ff9073af066c343e9867a393fe4c2555dcb33e89b937195feb9c1613d259edfcd459
+  languageName: node
+  linkType: hard
+
+"brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: 8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
   languageName: node
   linkType: hard
 
@@ -1803,6 +2205,13 @@ __metadata:
   version: 1.0.30001429
   resolution: "caniuse-lite@npm:1.0.30001429"
   checksum: d1658080248ef5ef0f5157423b2766026e6aa45642ce3b2cc74859b6a54e39881dd902397a2368324ed30ed0cd40250f11a4a4f3773453cd57b88db5e5e5c76a
+  languageName: node
+  linkType: hard
+
+"case@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "case@npm:1.6.3"
+  checksum: febe73278f910b0d28aab7efd6f51c235f9aa9e296148edb56dfb83fd58faa88308c30ce9a0122b6e53e0362c44f4407105bd5ef89c46860fc2b184e540fd68d
   languageName: node
   linkType: hard
 
@@ -2025,6 +2434,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crc-32@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "crc-32@npm:1.2.2"
+  bin:
+    crc32: bin/crc32.njs
+  checksum: ad2d0ad0cbd465b75dcaeeff0600f8195b686816ab5f3ba4c6e052a07f728c3e70df2e3ca9fd3d4484dc4ba70586e161ca5a2334ec8bf5a41bf022a6103ff243
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -2196,6 +2614,21 @@ __metadata:
   version: 1.4.284
   resolution: "electron-to-chromium@npm:1.4.284"
   checksum: be496e9dca6509dbdbb54dc32146fc99f8eb716d28a7ee8ccd3eba0066561df36fc51418d8bd7cf5a5891810bf56c0def3418e74248f51ea4a843d423603d10a
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:6.5.4":
+  version: 6.5.4
+  resolution: "elliptic@npm:6.5.4"
+  dependencies:
+    bn.js: ^4.11.9
+    brorand: ^1.1.0
+    hash.js: ^1.0.0
+    hmac-drbg: ^1.0.1
+    inherits: ^2.0.4
+    minimalistic-assert: ^1.0.1
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
   languageName: node
   linkType: hard
 
@@ -2625,6 +3058,18 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"ethereum-cryptography@npm:^1.1.2":
+  version: 1.2.0
+  resolution: "ethereum-cryptography@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": 1.2.0
+    "@noble/secp256k1": 1.7.1
+    "@scure/bip32": 1.1.5
+    "@scure/bip39": 1.1.1
+  checksum: 97e8e8253cb9f5a9271bd0201c37609c451c890eb85883b9c564f14743c3d7c673287406c93bf5604307593ee298ad9a03983388b85c11ca61461b9fc1a4f2c7
   languageName: node
   linkType: hard
 
@@ -3167,6 +3612,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash.js@npm:1.1.7, hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: ^2.0.3
+    minimalistic-assert: ^1.0.1
+  checksum: e350096e659c62422b85fa508e4b3669017311aa4c49b74f19f8e1bc7f3a54a584fdfd45326d4964d6011f2b2d882e38bea775a96046f2a61b7779a979629d8f
+  languageName: node
+  linkType: hard
+
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: ^1.0.3
+    minimalistic-assert: ^1.0.0
+    minimalistic-crypto-utils: ^1.0.1
+  checksum: bd30b6a68d7f22d63f10e1888aee497d7c2c5c0bb469e66bbdac99f143904d1dfe95f8131f95b3e86c86dd239963c9d972fcbe147e7cffa00e55d18585c43fe0
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -3298,7 +3764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -4047,6 +4513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-sha3@npm:0.8.0":
+  version: 0.8.0
+  resolution: "js-sha3@npm:0.8.0"
+  checksum: 75df77c1fc266973f06cce8309ce010e9e9f07ec35ab12022ed29b7f0d9c8757f5a73e1b35aa24840dced0dea7059085aa143d817aea9e188e2a80d569d9adce
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -4369,6 +4842,20 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-assert@npm:1.0.1"
+  checksum: cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
   languageName: node
   linkType: hard
 
@@ -5554,10 +6041,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"superstruct@npm:^0.16.7":
-  version: 0.16.7
-  resolution: "superstruct@npm:0.16.7"
-  checksum: c8c855ff6945da8a41048c6d236de7b1af5d4d9c31742b3ee54d65647c31597488620281f65e095d5efc9e2fbdaad529b8c8f2506c12569d428467c835a21477
+"superstruct@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "superstruct@npm:1.0.3"
+  checksum: 761790bb111e6e21ddd608299c252f3be35df543263a7ebbc004e840d01fcf8046794c274bcb351bdf3eae4600f79d317d085cdbb19ca05803a4361840cc9bb1
   languageName: node
   linkType: hard
 
@@ -6004,6 +6491,21 @@ __metadata:
     imurmurhash: ^0.1.4
     signal-exit: ^3.0.7
   checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
+  languageName: node
+  linkType: hard
+
+"ws@npm:7.4.6":
+  version: 7.4.6
+  resolution: "ws@npm:7.4.6"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 3a990b32ed08c72070d5e8913e14dfcd831919205be52a3ff0b4cdd998c8d554f167c9df3841605cde8b11d607768cacab3e823c58c96a5c08c987e093eb767a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rewrite error serialization to allow any error that conforms to the `JsonRpcError` JSON-compliant type. 

If the error does not conform to this type, it will be wrapped in an Internal RPC error and the original error will be included as the `data.cause`. Any non JSON-compliant props of the error will be removed.

Fixes https://github.com/MetaMask/eth-rpc-errors/issues/51