### PR TITLE
Rename exports to be more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,15 +91,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `serializeError`
   - If the object passed to the function has a `.message` property, it will preferred over the `.message` property of the fallback error when creating the returned serialized error object
 
-[Unreleased]: https://github.com/MetaMask/eth-rpc-errors/compare/v4.0.3...HEAD
-[4.0.3]: https://github.com/MetaMask/eth-rpc-errors/compare/v4.0.2...v4.0.3
-[4.0.2]: https://github.com/MetaMask/eth-rpc-errors/compare/v4.0.1...v4.0.2
-[4.0.1]: https://github.com/MetaMask/eth-rpc-errors/compare/v4.0.0...v4.0.1
-[4.0.0]: https://github.com/MetaMask/eth-rpc-errors/compare/v3.0.0...v4.0.0
-[3.0.0]: https://github.com/MetaMask/eth-rpc-errors/compare/v2.1.1...v3.0.0
-[2.1.1]: https://github.com/MetaMask/eth-rpc-errors/compare/v2.1.0...v2.1.1
-[2.1.0]: https://github.com/MetaMask/eth-rpc-errors/compare/v2.0.2...v2.1.0
-[2.0.2]: https://github.com/MetaMask/eth-rpc-errors/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/MetaMask/eth-rpc-errors/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/MetaMask/eth-rpc-errors/compare/v1.1.0...v2.0.0
-[1.1.0]: https://github.com/MetaMask/eth-rpc-errors/releases/tag/v1.1.0
+[Unreleased]: https://github.com/MetaMask/rpc-errors/compare/v4.0.3...HEAD
+[4.0.3]: https://github.com/MetaMask/rpc-errors/compare/v4.0.2...v4.0.3
+[4.0.2]: https://github.com/MetaMask/rpc-errors/compare/v4.0.1...v4.0.2
+[4.0.1]: https://github.com/MetaMask/rpc-errors/compare/v4.0.0...v4.0.1
+[4.0.0]: https://github.com/MetaMask/rpc-errors/compare/v3.0.0...v4.0.0
+[3.0.0]: https://github.com/MetaMask/rpc-errors/compare/v2.1.1...v3.0.0
+[2.1.1]: https://github.com/MetaMask/rpc-errors/compare/v2.1.0...v2.1.1
+[2.1.0]: https://github.com/MetaMask/rpc-errors/compare/v2.0.2...v2.1.0
+[2.0.2]: https://github.com/MetaMask/rpc-errors/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/MetaMask/rpc-errors/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/MetaMask/rpc-errors/compare/v1.1.0...v2.0.0
+[1.1.0]: https://github.com/MetaMask/rpc-errors/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ or
 ## Usage
 
 ```js
-import { ethErrors } from '@metamask/rpc-errors';
+import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 
-throw ethErrors.provider.unauthorized();
+throw rpcErrors.invalidRequest();
 // or
-throw ethErrors.provider.unauthorized('my custom message');
+throw providerErrors.unauthorized('my custom message');
 ```
 
 ## Supported Errors
 
+- Generic JSON RPC 2.0 errors
+  - Per [JSON RPC 2.0 spec](https://www.jsonrpc.org/specification#error_object)
 - Ethereum JSON RPC
   - Per [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474#error-codes)
-    - This includes all
-      [JSON RPC 2.0 errors](https://www.jsonrpc.org/specification#error_object)
 - Ethereum Provider errors
   - Per [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193#provider-errors)
     - Does **not** yet support [`CloseEvent` errors or status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
@@ -37,16 +37,16 @@ throw ethErrors.provider.unauthorized('my custom message');
 ## API
 
 ```js
-import { ethErrors } from '@metamask/rpc-errors';
+import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 
-// Ethereum RPC errors are namespaced under "ethErrors.rpc"
-response.error = ethErrors.rpc.methodNotFound({
+// JSON-RPC errors are namespaced under "rpcErrors"
+response.error = rpcErrors.methodNotFound({
   message: optionalCustomMessage,
   data: optionalData,
 });
 
-// Provider errors namespaced under ethErrors.provider
-response.error = ethErrors.provider.unauthorized({
+// Provider errors namespaced under providerErrors
+response.error = providerErrors.unauthorized({
   message: optionalCustomMessage,
   data: optionalData,
 });
@@ -54,11 +54,11 @@ response.error = ethErrors.provider.unauthorized({
 // each error getter takes a single "opts" argument
 // for most errors, this can be replaced with a single string, which becomes
 // the error message
-response.error = ethErrors.provider.unauthorized(customMessage);
+response.error = providerErrors.unauthorized(customMessage);
 
 // if an error getter accepts a single string, all arguments can be omitted
-response.error = ethErrors.provider.unauthorized();
-response.error = ethErrors.provider.unauthorized({});
+response.error = providerErrors.unauthorized();
+response.error = providerErrors.unauthorized({});
 
 // omitting the message will produce an error with a default message per
 // the relevant spec
@@ -67,13 +67,13 @@ response.error = ethErrors.provider.unauthorized({});
 // "data" property
 
 // the JSON RPC 2.0 server error requires a valid code
-response.error = ethErrors.rpc.server({
+response.error = rpcErrors.server({
   code: -32031,
 });
 
 // custom Ethereum Provider errors require a valid code and message
 // valid codes are integers i such that: 1000 <= i <= 4999
-response.error = ethErrors.provider.custom({
+response.error = providerErrors.custom({
   code: 1001,
   message: 'foo',
 });
@@ -109,7 +109,7 @@ response.error = serializeError(maybeAnError, fallbackError)
 /**
  * Classes
  */
-import { EthereumRpcError, EthereumProviderError } from '@metamask/rpc-errors';
+import { JsonRpcError, EthereumProviderError } from '@metamask/rpc-errors';
 
 /**
  * getMessageFromCode and errorCodes
@@ -126,11 +126,11 @@ const message2 = getMessageFromCode(someCode, myFallback);
 const message3 = getMessageFromCode(someCode, null);
 
 // {
-//   rpc: { [errorName]: code, ... },
-//   provider: { [errorName]: code, ... },
+//   rpcErrors: { [errorName]: code, ... },
+//   providerErrors: { [errorName]: code, ... },
 // }
-const code1 = errorCodes.rpc.parse;
-const code2 = errorCodes.provider.userRejectedRequest;
+const code1 = rpcErrors.parse;
+const code2 = providerErrors.userRejectedRequest;
 
 // all codes in errorCodes have default messages
 const message4 = getMessageFromCode(code1);

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ throw providerErrors.unauthorized('my custom message');
 ```js
 import { rpcErrors, providerErrors } from '@metamask/rpc-errors';
 
-// JSON-RPC errors are namespaced under "rpcErrors"
+// JSON-RPC errors and Ethereum EIP-1474 errors are namespaced under "rpcErrors"
 response.error = rpcErrors.methodNotFound({
   message: optionalCustomMessage,
   data: optionalData,
 });
 
-// Provider errors namespaced under providerErrors
+// Ethereum EIP-1193 Provider errors namespaced under "providerErrors"
 response.error = providerErrors.unauthorized({
   message: optionalCustomMessage,
   data: optionalData,

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.44,
-      functions: 85,
-      lines: 96.87,
-      statements: 96.87,
+      branches: 94.5,
+      functions: 85.36,
+      lines: 96.88,
+      statements: 96.88,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "errors",
     "utility"
   ],
-  "homepage": "https://github.com/MetaMask/eth-rpc-errors#readme",
+  "homepage": "https://github.com/MetaMask/rpc-errors#readme",
   "bugs": {
-    "url": "https://github.com/MetaMask/eth-rpc-errors/issues"
+    "url": "https://github.com/MetaMask/rpc-errors/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/eth-rpc-errors.git"
+    "url": "https://github.com/MetaMask/rpc-errors.git"
   },
   "license": "MIT",
   "author": "Erik Marks <rekmarks@protonmail.com>",

--- a/src/__fixtures__/errors.ts
+++ b/src/__fixtures__/errors.ts
@@ -1,4 +1,4 @@
-import { ethErrors } from '..';
+import { rpcErrors } from '..';
 
 export const dummyData = { foo: 'bar' };
 export const dummyMessage = 'baz';
@@ -26,11 +26,11 @@ export const validError1 = {
   message: dummyMessage,
   data: Object.assign({}, dummyData),
 };
-export const validError2 = ethErrors.rpc.parse();
+export const validError2 = rpcErrors.parse();
 delete validError2.stack;
-export const validError3 = ethErrors.rpc.parse(dummyMessage);
+export const validError3 = rpcErrors.parse(dummyMessage);
 delete validError3.stack;
-export const validError4 = ethErrors.rpc.parse({
+export const validError4 = rpcErrors.parse({
   message: dummyMessage,
   data: Object.assign({}, dummyData),
 });

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -1,7 +1,7 @@
 import safeStringify from 'fast-safe-stringify';
-import { Json, JsonRpcError } from '@metamask/utils';
+import { Json, JsonRpcError as SerializedJsonRpcError } from '@metamask/utils';
 
-export { JsonRpcError };
+export { SerializedJsonRpcError };
 
 /**
  * Error subclass implementing JSON RPC 2.0 errors and Ethereum RPC errors
@@ -9,7 +9,7 @@ export { JsonRpcError };
  *
  * Permits any integer error code.
  */
-export class EthereumRpcError<T extends Json> extends Error {
+export class JsonRpcError<T extends Json> extends Error {
   public code: number;
 
   public data?: T;
@@ -20,7 +20,7 @@ export class EthereumRpcError<T extends Json> extends Error {
     }
 
     if (!message || typeof message !== 'string') {
-      throw new Error('"message" must be a nonempty string.');
+      throw new Error('"message" must be a non-empty string.');
     }
 
     super(message);
@@ -35,8 +35,8 @@ export class EthereumRpcError<T extends Json> extends Error {
    *
    * @returns A plain object with all public class properties.
    */
-  serialize(): JsonRpcError {
-    const serialized: JsonRpcError = {
+  serialize(): SerializedJsonRpcError {
+    const serialized: SerializedJsonRpcError = {
       code: this.code,
       message: this.message,
     };
@@ -65,7 +65,7 @@ export class EthereumRpcError<T extends Json> extends Error {
  * Error subclass implementing Ethereum Provider errors per EIP-1193.
  * Permits integer error codes in the [ 1000 <= 4999 ] range.
  */
-export class EthereumProviderError<T extends Json> extends EthereumRpcError<T> {
+export class EthereumProviderError<T extends Json> extends JsonRpcError<T> {
   /**
    * Create an Ethereum Provider JSON-RPC error.
    *

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -5,8 +5,7 @@ import {
   SERVER_ERROR_CODE,
   CUSTOM_ERROR_CODE,
 } from './__fixtures__';
-import { providerErrors } from './errors';
-import { rpcErrors, errorCodes } from '.';
+import { rpcErrors, providerErrors, errorCodes } from '.';
 
 describe('rpcErrors.invalidInput', () => {
   it('accepts a single string argument where appropriate', () => {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -5,19 +5,20 @@ import {
   SERVER_ERROR_CODE,
   CUSTOM_ERROR_CODE,
 } from './__fixtures__';
-import { ethErrors, errorCodes } from '.';
+import { providerErrors } from './errors';
+import { rpcErrors, errorCodes } from '.';
 
-describe('ethErrors.rpc.invalidInput', () => {
+describe('rpcErrors.invalidInput', () => {
   it('accepts a single string argument where appropriate', () => {
-    const err = ethErrors.rpc.invalidInput(CUSTOM_ERROR_MESSAGE);
+    const err = rpcErrors.invalidInput(CUSTOM_ERROR_MESSAGE);
     expect(err.code).toBe(errorCodes.rpc.invalidInput);
     expect(err.message).toBe(CUSTOM_ERROR_MESSAGE);
   });
 });
 
-describe('ethErrors.provider.unauthorized', () => {
+describe('providerErrors.unauthorized', () => {
   it('accepts a single string argument where appropriate', () => {
-    const err = ethErrors.provider.unauthorized(CUSTOM_ERROR_MESSAGE);
+    const err = providerErrors.unauthorized(CUSTOM_ERROR_MESSAGE);
     expect(err.code).toBe(errorCodes.provider.unauthorized);
     expect(err.message).toBe(CUSTOM_ERROR_MESSAGE);
   });
@@ -27,7 +28,7 @@ describe('custom provider error options', () => {
   it('throws if the value is not an options object', () => {
     expect(() => {
       // @ts-expect-error Invalid input
-      ethErrors.provider.custom('bar');
+      providerErrors.custom('bar');
     }).toThrow(
       'Ethereum Provider custom errors must provide single object argument.',
     );
@@ -36,11 +37,11 @@ describe('custom provider error options', () => {
   it('throws if the value is invalid', () => {
     expect(() => {
       // @ts-expect-error Invalid input
-      ethErrors.provider.custom({ code: 4009, message: 2 });
+      providerErrors.custom({ code: 4009, message: 2 });
     }).toThrow('"message" must be a nonempty string');
 
     expect(() => {
-      ethErrors.provider.custom({ code: 4009, message: '' });
+      providerErrors.custom({ code: 4009, message: '' });
     }).toThrow('"message" must be a nonempty string');
   });
 });
@@ -49,24 +50,24 @@ describe('ethError.rpc.server', () => {
   it('throws on invalid input', () => {
     expect(() => {
       // @ts-expect-error Invalid input
-      ethErrors.rpc.server('bar');
+      rpcErrors.server('bar');
     }).toThrow(
       'Ethereum RPC Server errors must provide single object argument.',
     );
 
     expect(() => {
       // @ts-expect-error Invalid input
-      ethErrors.rpc.server({ code: 'bar' });
+      rpcErrors.server({ code: 'bar' });
     }).toThrow('"code" must be an integer such that: -32099 <= code <= -32005');
 
     expect(() => {
-      ethErrors.rpc.server({ code: 1 });
+      rpcErrors.server({ code: 1 });
     }).toThrow('"code" must be an integer such that: -32099 <= code <= -32005');
   });
 });
 
-describe('ethError.rpc', () => {
-  it.each(Object.entries(ethErrors.rpc).filter(([key]) => key !== 'server'))(
+describe('rpcErrors', () => {
+  it.each(Object.entries(rpcErrors).filter(([key]) => key !== 'server'))(
     '%s returns appropriate value',
     (key, value) => {
       const createError = value as any;
@@ -86,7 +87,7 @@ describe('ethError.rpc', () => {
   );
 
   it('server returns appropriate value', () => {
-    const error = ethErrors.rpc.server({
+    const error = rpcErrors.server({
       code: SERVER_ERROR_CODE,
       data: Object.assign({}, dummyData),
     });
@@ -96,24 +97,25 @@ describe('ethError.rpc', () => {
   });
 });
 
-describe('ethError.provider', () => {
-  it.each(
-    Object.entries(ethErrors.provider).filter(([key]) => key !== 'custom'),
-  )('%s returns appropriate value', (key, value) => {
-    const createError = value as any;
-    const error = createError({
-      message: null,
-      data: Object.assign({}, dummyData),
-    });
-    // @ts-expect-error TypeScript does not like indexing into this with the key
-    const providerCode = errorCodes.provider[key];
-    expect(error.code >= 1000 && error.code < 5000).toBe(true);
-    expect(error.code).toBe(providerCode);
-    expect(error.message).toBe(getMessageFromCode(providerCode));
-  });
+describe('providerErrors', () => {
+  it.each(Object.entries(providerErrors).filter(([key]) => key !== 'custom'))(
+    '%s returns appropriate value',
+    (key, value) => {
+      const createError = value as any;
+      const error = createError({
+        message: null,
+        data: Object.assign({}, dummyData),
+      });
+      // @ts-expect-error TypeScript does not like indexing into this with the key
+      const providerCode = errorCodes.provider[key];
+      expect(error.code >= 1000 && error.code < 5000).toBe(true);
+      expect(error.code).toBe(providerCode);
+      expect(error.message).toBe(getMessageFromCode(providerCode));
+    },
+  );
 
   it('custom returns appropriate value', () => {
-    const error = ethErrors.provider.custom({
+    const error = providerErrors.custom({
       code: CUSTOM_ERROR_CODE,
       message: CUSTOM_ERROR_MESSAGE,
       data: Object.assign({}, dummyData),

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
 import { Json } from '@metamask/utils';
-import { EthereumRpcError, EthereumProviderError } from './classes';
+import { JsonRpcError, EthereumProviderError } from './classes';
 import { getMessageFromCode } from './utils';
 import { errorCodes } from './error-constants';
 
@@ -14,220 +14,218 @@ type ServerErrorOptions<T extends Json> = {
 
 type CustomErrorArg<T extends Json> = ServerErrorOptions<T>;
 
-type EthErrorsArg<T extends Json> = EthereumErrorOptions<T> | string;
+type JsonRpcErrorsArg<T extends Json> = EthereumErrorOptions<T> | string;
 
-export const ethErrors = {
-  rpc: {
-    /**
-     * Get a JSON RPC 2.0 Parse (-32700) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    parse: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.parse, arg),
+export const rpcErrors = {
+  /**
+   * Get a JSON RPC 2.0 Parse (-32700) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  parse: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.parse, arg),
 
-    /**
-     * Get a JSON RPC 2.0 Invalid Request (-32600) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    invalidRequest: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.invalidRequest, arg),
+  /**
+   * Get a JSON RPC 2.0 Invalid Request (-32600) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  invalidRequest: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.invalidRequest, arg),
 
-    /**
-     * Get a JSON RPC 2.0 Invalid Params (-32602) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    invalidParams: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.invalidParams, arg),
+  /**
+   * Get a JSON RPC 2.0 Invalid Params (-32602) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  invalidParams: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.invalidParams, arg),
 
-    /**
-     * Get a JSON RPC 2.0 Method Not Found (-32601) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    methodNotFound: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.methodNotFound, arg),
+  /**
+   * Get a JSON RPC 2.0 Method Not Found (-32601) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  methodNotFound: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.methodNotFound, arg),
 
-    /**
-     * Get a JSON RPC 2.0 Internal (-32603) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    internal: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.internal, arg),
+  /**
+   * Get a JSON RPC 2.0 Internal (-32603) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  internal: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.internal, arg),
 
-    /**
-     * Get a JSON RPC 2.0 Server error.
-     * Permits integer error codes in the [ -32099 <= -32005 ] range.
-     * Codes -32000 through -32004 are reserved by EIP-1474.
-     *
-     * @param opts - The error options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    server: <T extends Json>(opts: ServerErrorOptions<T>) => {
-      if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
-        throw new Error(
-          'Ethereum RPC Server errors must provide single object argument.',
-        );
-      }
-      const { code } = opts;
-      if (!Number.isInteger(code) || code > -32005 || code < -32099) {
-        throw new Error(
-          '"code" must be an integer such that: -32099 <= code <= -32005',
-        );
-      }
-      return getEthJsonRpcError(code, opts);
-    },
-
-    /**
-     * Get an Ethereum JSON RPC Invalid Input (-32000) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    invalidInput: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.invalidInput, arg),
-
-    /**
-     * Get an Ethereum JSON RPC Resource Not Found (-32001) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    resourceNotFound: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.resourceNotFound, arg),
-
-    /**
-     * Get an Ethereum JSON RPC Resource Unavailable (-32002) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    resourceUnavailable: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.resourceUnavailable, arg),
-
-    /**
-     * Get an Ethereum JSON RPC Transaction Rejected (-32003) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    transactionRejected: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.transactionRejected, arg),
-
-    /**
-     * Get an Ethereum JSON RPC Method Not Supported (-32004) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    methodNotSupported: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.methodNotSupported, arg),
-
-    /**
-     * Get an Ethereum JSON RPC Limit Exceeded (-32005) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumRpcError} class.
-     */
-    limitExceeded: <T extends Json>(arg?: EthErrorsArg<T>) =>
-      getEthJsonRpcError(errorCodes.rpc.limitExceeded, arg),
+  /**
+   * Get a JSON RPC 2.0 Server error.
+   * Permits integer error codes in the [ -32099 <= -32005 ] range.
+   * Codes -32000 through -32004 are reserved by EIP-1474.
+   *
+   * @param opts - The error options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  server: <T extends Json>(opts: ServerErrorOptions<T>) => {
+    if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
+      throw new Error(
+        'Ethereum RPC Server errors must provide single object argument.',
+      );
+    }
+    const { code } = opts;
+    if (!Number.isInteger(code) || code > -32005 || code < -32099) {
+      throw new Error(
+        '"code" must be an integer such that: -32099 <= code <= -32005',
+      );
+    }
+    return getJsonRpcError(code, opts);
   },
 
-  provider: {
-    /**
-     * Get an Ethereum Provider User Rejected Request (4001) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    userRejectedRequest: <T extends Json>(arg?: EthErrorsArg<T>) => {
-      return getEthProviderError(errorCodes.provider.userRejectedRequest, arg);
-    },
+  /**
+   * Get an Ethereum JSON RPC Invalid Input (-32000) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  invalidInput: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.invalidInput, arg),
 
-    /**
-     * Get an Ethereum Provider Unauthorized (4100) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    unauthorized: <T extends Json>(arg?: EthErrorsArg<T>) => {
-      return getEthProviderError(errorCodes.provider.unauthorized, arg);
-    },
+  /**
+   * Get an Ethereum JSON RPC Resource Not Found (-32001) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  resourceNotFound: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.resourceNotFound, arg),
 
-    /**
-     * Get an Ethereum Provider Unsupported Method (4200) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    unsupportedMethod: <T extends Json>(arg?: EthErrorsArg<T>) => {
-      return getEthProviderError(errorCodes.provider.unsupportedMethod, arg);
-    },
+  /**
+   * Get an Ethereum JSON RPC Resource Unavailable (-32002) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  resourceUnavailable: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.resourceUnavailable, arg),
 
-    /**
-     * Get an Ethereum Provider Not Connected (4900) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    disconnected: <T extends Json>(arg?: EthErrorsArg<T>) => {
-      return getEthProviderError(errorCodes.provider.disconnected, arg);
-    },
+  /**
+   * Get an Ethereum JSON RPC Transaction Rejected (-32003) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  transactionRejected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.transactionRejected, arg),
 
-    /**
-     * Get an Ethereum Provider Chain Not Connected (4901) error.
-     *
-     * @param arg - The error message or options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    chainDisconnected: <T extends Json>(arg?: EthErrorsArg<T>) => {
-      return getEthProviderError(errorCodes.provider.chainDisconnected, arg);
-    },
+  /**
+   * Get an Ethereum JSON RPC Method Not Supported (-32004) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  methodNotSupported: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.methodNotSupported, arg),
 
-    /**
-     * Get a custom Ethereum Provider error.
-     *
-     * @param opts - The error options bag.
-     * @returns An instance of the {@link EthereumProviderError} class.
-     */
-    custom: <T extends Json>(opts: CustomErrorArg<T>) => {
-      if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
-        throw new Error(
-          'Ethereum Provider custom errors must provide single object argument.',
-        );
-      }
+  /**
+   * Get an Ethereum JSON RPC Limit Exceeded (-32005) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link JsonRpcError} class.
+   */
+  limitExceeded: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+    getJsonRpcError(errorCodes.rpc.limitExceeded, arg),
+};
 
-      const { code, message, data } = opts;
+export const providerErrors = {
+  /**
+   * Get an Ethereum Provider User Rejected Request (4001) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  userRejectedRequest: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+    return getEthProviderError(errorCodes.provider.userRejectedRequest, arg);
+  },
 
-      if (!message || typeof message !== 'string') {
-        throw new Error('"message" must be a nonempty string');
-      }
-      return new EthereumProviderError(code, message, data);
-    },
+  /**
+   * Get an Ethereum Provider Unauthorized (4100) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  unauthorized: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+    return getEthProviderError(errorCodes.provider.unauthorized, arg);
+  },
+
+  /**
+   * Get an Ethereum Provider Unsupported Method (4200) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  unsupportedMethod: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+    return getEthProviderError(errorCodes.provider.unsupportedMethod, arg);
+  },
+
+  /**
+   * Get an Ethereum Provider Not Connected (4900) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  disconnected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+    return getEthProviderError(errorCodes.provider.disconnected, arg);
+  },
+
+  /**
+   * Get an Ethereum Provider Chain Not Connected (4901) error.
+   *
+   * @param arg - The error message or options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  chainDisconnected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+    return getEthProviderError(errorCodes.provider.chainDisconnected, arg);
+  },
+
+  /**
+   * Get a custom Ethereum Provider error.
+   *
+   * @param opts - The error options bag.
+   * @returns An instance of the {@link EthereumProviderError} class.
+   */
+  custom: <T extends Json>(opts: CustomErrorArg<T>) => {
+    if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
+      throw new Error(
+        'Ethereum Provider custom errors must provide single object argument.',
+      );
+    }
+
+    const { code, message, data } = opts;
+
+    if (!message || typeof message !== 'string') {
+      throw new Error('"message" must be a nonempty string');
+    }
+    return new EthereumProviderError(code, message, data);
   },
 };
 
 /**
- * Get an Ethereum JSON-RPC error class instance.
+ * Get a generic JSON-RPC error class instance.
  *
  * @param code - The error code.
  * @param arg - The error message or options bag.
- * @returns An instance of the {@link EthereumRpcError} class.
+ * @returns An instance of the {@link JsonRpcError} class.
  */
-function getEthJsonRpcError<T extends Json>(
+function getJsonRpcError<T extends Json>(
   code: number,
-  arg?: EthErrorsArg<T>,
-): EthereumRpcError<T> {
+  arg?: JsonRpcErrorsArg<T>,
+): JsonRpcError<T> {
   const [message, data] = parseOpts(arg);
-  return new EthereumRpcError(code, message || getMessageFromCode(code), data);
+  return new JsonRpcError(code, message || getMessageFromCode(code), data);
 }
 
 /**
@@ -239,7 +237,7 @@ function getEthJsonRpcError<T extends Json>(
  */
 function getEthProviderError<T extends Json>(
   code: number,
-  arg?: EthErrorsArg<T>,
+  arg?: JsonRpcErrorsArg<T>,
 ): EthereumProviderError<T> {
   const [message, data] = parseOpts(arg);
   return new EthereumProviderError(
@@ -256,7 +254,7 @@ function getEthProviderError<T extends Json>(
  * @returns A tuple containing the error message and optional data.
  */
 function parseOpts<T extends Json>(
-  arg?: EthErrorsArg<T>,
+  arg?: JsonRpcErrorsArg<T>,
 ): [message?: string | undefined, data?: T | undefined] {
   if (arg) {
     if (typeof arg === 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import { JsonRpcError, EthereumProviderError } from './classes';
 import { serializeError, getMessageFromCode } from './utils';
-import { rpcErrors } from './errors';
+import { rpcErrors, providerErrors } from './errors';
 import { errorCodes } from './error-constants';
 
 export {
   errorCodes,
   rpcErrors,
+  providerErrors,
   JsonRpcError,
   EthereumProviderError,
   serializeError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { EthereumRpcError, EthereumProviderError } from './classes';
+import { JsonRpcError, EthereumProviderError } from './classes';
 import { serializeError, getMessageFromCode } from './utils';
-import { ethErrors } from './errors';
+import { rpcErrors } from './errors';
 import { errorCodes } from './error-constants';
 
 export {
   errorCodes,
-  ethErrors,
-  EthereumRpcError,
+  rpcErrors,
+  JsonRpcError,
   EthereumProviderError,
   serializeError,
   getMessageFromCode,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -16,7 +16,7 @@ import {
   dummyData,
 } from './__fixtures__';
 import { getMessageFromCode, serializeError } from './utils';
-import { errorCodes, ethErrors } from '.';
+import { errorCodes, rpcErrors } from '.';
 
 const rpcCodes = errorCodes.rpc;
 
@@ -230,8 +230,8 @@ describe('serializeError', () => {
     });
   });
 
-  it('handles EthereumRpcError', () => {
-    const error = ethErrors.rpc.invalidParams();
+  it('handles JsonRpcError', () => {
+    const error = rpcErrors.invalidParams();
     const result = serializeError(error);
     expect(result).toStrictEqual({
       code: error.code,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import {
   isObject,
   isJsonRpcError,
   Json,
-  JsonRpcError,
+  JsonRpcError as SerializedJsonRpcError,
   RuntimeObject,
 } from '@metamask/utils';
 import { errorCodes, errorValues } from './error-constants';
@@ -12,7 +12,7 @@ import { errorCodes, errorValues } from './error-constants';
 const FALLBACK_ERROR_CODE = errorCodes.rpc.internal;
 const FALLBACK_MESSAGE =
   'Unspecified error message. This is a bug, please report it.';
-const FALLBACK_ERROR: JsonRpcError = {
+const FALLBACK_ERROR: SerializedJsonRpcError = {
   code: FALLBACK_ERROR_CODE,
   message: getMessageFromCode(FALLBACK_ERROR_CODE),
 };
@@ -76,7 +76,7 @@ export function isValidCode(code: unknown): code is number {
 export function serializeError(
   error: unknown,
   { fallbackError = FALLBACK_ERROR, shouldIncludeStack = true } = {},
-): JsonRpcError {
+): SerializedJsonRpcError {
   if (!isJsonRpcError(fallbackError)) {
     throw new Error(
       'Must provide fallback error with integer number code and string message.',
@@ -99,7 +99,10 @@ export function serializeError(
  * @param fallbackError - A JSON serializable fallback error.
  * @returns A JSON serializable error object.
  */
-function buildError(error: unknown, fallbackError: JsonRpcError): JsonRpcError {
+function buildError(
+  error: unknown,
+  fallbackError: SerializedJsonRpcError,
+): SerializedJsonRpcError {
   // If an error specifies a `serialize` function, we call it and return the result.
   if (
     error &&


### PR DESCRIPTION
- Exports have been renamed to be more generic.
   - `ethErrors.rpc` is now exported as `rpcErrors`.
   - `ethErrors.provider` is now exported as `providerErrors`. This is still Ethereum-specific.
- Some related classes have been renamed to be more generic.
   - `(Serialized)EthereumRpcError` is now `(Serialized)JsonRpcError`.
- References to `eth-rpc-errors` have been updated to `rpc-errors`.
   - We should rename the GitHub repository after merging this.

This is technically a breaking change, but we will be publishing this package under a new name.