### PR TITLE
Add 'publishConfig' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,9 @@
   "packageManager": "yarn@3.2.4",
   "engines": {
     "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Description

This pull request adds the `publishConfig` object to the `package.json` file in order to configure the registry and the
access level for publishing the package to npmjs. This change has been made to ensure that the publication process is
consistent and error-free, and that the package is deployed to the correct registry with the correct access level.

Before this change, there was no configuration for publishing the package, which caused the following error:

> 402 Payment Required - PUT https://registry.npmjs.org/@metamask%2frpc-errors - You must sign up for private packages

## Changes

1. Add a `publishConfig` object to `package.json` to configure the registry and the access level for publishing the
   package.