### PR TITLE
Allow passing a cause to predefined error functions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,11 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['./src/**/*.ts', '!./src/__fixtures__/**/*'],
+  collectCoverageFrom: [
+    './src/**/*.ts',
+    '!./src/__fixtures__/**/*',
+    '!./src/index.ts',
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
@@ -41,10 +45,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 94.5,
-      functions: 85.36,
-      lines: 97.08,
-      statements: 97.08,
+      branches: 94.25,
+      functions: 94.11,
+      lines: 97.02,
+      statements: 97.02,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,8 +43,8 @@ module.exports = {
     global: {
       branches: 94.5,
       functions: 85.36,
-      lines: 96.88,
-      statements: 96.88,
+      lines: 97.08,
+      statements: 97.08,
     },
   },
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,3 +1,4 @@
+import { assert, isPlainObject } from '@metamask/utils';
 import { getMessageFromCode, JSON_RPC_SERVER_ERROR_MESSAGE } from './utils';
 import {
   dummyData,
@@ -103,8 +104,12 @@ describe('rpcErrors', () => {
       },
     });
 
-    expect(error.serialize().data.cause).not.toBeInstanceOf(Error);
-    expect(error.serialize().data).toStrictEqual({
+    const serializedError = error.serialize();
+    assert(serializedError.data);
+    assert(isPlainObject(serializedError.data));
+
+    expect(serializedError.data.cause).not.toBeInstanceOf(Error);
+    expect(serializedError.data).toStrictEqual({
       foo: 'bar',
       cause: {
         message: 'foo',
@@ -150,8 +155,12 @@ describe('providerErrors', () => {
       },
     });
 
-    expect(error.serialize().data.cause).not.toBeInstanceOf(Error);
-    expect(error.serialize().data).toStrictEqual({
+    const serializedError = error.serialize();
+    assert(serializedError.data);
+    assert(isPlainObject(serializedError.data));
+
+    expect(serializedError.data.cause).not.toBeInstanceOf(Error);
+    expect(serializedError.data).toStrictEqual({
       foo: 'bar',
       cause: {
         message: 'foo',

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -45,7 +45,7 @@ describe('custom provider error options', () => {
   });
 });
 
-describe('ethError.rpc.server', () => {
+describe('rpcErrors.server', () => {
   it('throws on invalid input', () => {
     expect(() => {
       // @ts-expect-error Invalid input
@@ -62,6 +62,16 @@ describe('ethError.rpc.server', () => {
     expect(() => {
       rpcErrors.server({ code: 1 });
     }).toThrow('"code" must be an integer such that: -32099 <= code <= -32005');
+  });
+
+  it('returns appropriate value', () => {
+    const error = rpcErrors.server({
+      code: SERVER_ERROR_CODE,
+      data: Object.assign({}, dummyData),
+    });
+
+    expect(error.code <= -32000 && error.code >= -32099).toBe(true);
+    expect(error.message).toBe(JSON_RPC_SERVER_ERROR_MESSAGE);
   });
 });
 
@@ -85,14 +95,21 @@ describe('rpcErrors', () => {
     },
   );
 
-  it('server returns appropriate value', () => {
-    const error = rpcErrors.server({
-      code: SERVER_ERROR_CODE,
-      data: Object.assign({}, dummyData),
+  it('serializes a cause', () => {
+    const error = rpcErrors.invalidInput({
+      data: {
+        foo: 'bar',
+        cause: new Error('foo'),
+      },
     });
 
-    expect(error.code <= -32000 && error.code >= -32099).toBe(true);
-    expect(error.message).toBe(JSON_RPC_SERVER_ERROR_MESSAGE);
+    expect(error.serialize().data).toStrictEqual({
+      foo: 'bar',
+      cause: {
+        message: 'foo',
+        stack: expect.stringContaining('Error: foo'),
+      },
+    });
   });
 });
 
@@ -122,5 +139,22 @@ describe('providerErrors', () => {
     expect(error.code >= 1000 && error.code < 5000).toBe(true);
     expect(error.code).toBe(CUSTOM_ERROR_CODE);
     expect(error.message).toBe(CUSTOM_ERROR_MESSAGE);
+  });
+
+  it('serializes a cause', () => {
+    const error = providerErrors.unauthorized({
+      data: {
+        foo: 'bar',
+        cause: new Error('foo'),
+      },
+    });
+
+    expect(error.serialize().data).toStrictEqual({
+      foo: 'bar',
+      cause: {
+        message: 'foo',
+        stack: expect.stringContaining('Error: foo'),
+      },
+    });
   });
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -103,6 +103,7 @@ describe('rpcErrors', () => {
       },
     });
 
+    expect(error.serialize().data).not.toBeInstanceOf(Error);
     expect(error.serialize().data).toStrictEqual({
       foo: 'bar',
       cause: {
@@ -149,6 +150,7 @@ describe('providerErrors', () => {
       },
     });
 
+    expect(error.serialize().data).not.toBeInstanceOf(Error);
     expect(error.serialize().data).toStrictEqual({
       foo: 'bar',
       cause: {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -103,7 +103,7 @@ describe('rpcErrors', () => {
       },
     });
 
-    expect(error.serialize().data).not.toBeInstanceOf(Error);
+    expect(error.serialize().data.cause).not.toBeInstanceOf(Error);
     expect(error.serialize().data).toStrictEqual({
       foo: 'bar',
       cause: {
@@ -150,7 +150,7 @@ describe('providerErrors', () => {
       },
     });
 
-    expect(error.serialize().data).not.toBeInstanceOf(Error);
+    expect(error.serialize().data.cause).not.toBeInstanceOf(Error);
     expect(error.serialize().data).toStrictEqual({
       foo: 'bar',
       cause: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,20 +1,21 @@
-import { Json } from '@metamask/utils';
 import { JsonRpcError, EthereumProviderError } from './classes';
-import { getMessageFromCode } from './utils';
+import { DataWithOptionalCause, getMessageFromCode } from './utils';
 import { errorCodes } from './error-constants';
 
-type EthereumErrorOptions<T extends Json> = {
+type EthereumErrorOptions<T extends DataWithOptionalCause> = {
   message?: string;
   data?: T;
 };
 
-type ServerErrorOptions<T extends Json> = {
+type ServerErrorOptions<T extends DataWithOptionalCause> = {
   code: number;
 } & EthereumErrorOptions<T>;
 
-type CustomErrorArg<T extends Json> = ServerErrorOptions<T>;
+type CustomErrorArg<T extends DataWithOptionalCause> = ServerErrorOptions<T>;
 
-type JsonRpcErrorsArg<T extends Json> = EthereumErrorOptions<T> | string;
+type JsonRpcErrorsArg<T extends DataWithOptionalCause> =
+  | EthereumErrorOptions<T>
+  | string;
 
 export const rpcErrors = {
   /**
@@ -23,7 +24,7 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  parse: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+  parse: <T extends DataWithOptionalCause>(arg?: JsonRpcErrorsArg<T>) =>
     getJsonRpcError(errorCodes.rpc.parse, arg),
 
   /**
@@ -32,8 +33,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  invalidRequest: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.invalidRequest, arg),
+  invalidRequest: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.invalidRequest, arg),
 
   /**
    * Get a JSON RPC 2.0 Invalid Params (-32602) error.
@@ -41,7 +43,7 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  invalidParams: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+  invalidParams: <T extends DataWithOptionalCause>(arg?: JsonRpcErrorsArg<T>) =>
     getJsonRpcError(errorCodes.rpc.invalidParams, arg),
 
   /**
@@ -50,8 +52,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  methodNotFound: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.methodNotFound, arg),
+  methodNotFound: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.methodNotFound, arg),
 
   /**
    * Get a JSON RPC 2.0 Internal (-32603) error.
@@ -59,7 +62,7 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  internal: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+  internal: <T extends DataWithOptionalCause>(arg?: JsonRpcErrorsArg<T>) =>
     getJsonRpcError(errorCodes.rpc.internal, arg),
 
   /**
@@ -70,7 +73,7 @@ export const rpcErrors = {
    * @param opts - The error options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  server: <T extends Json>(opts: ServerErrorOptions<T>) => {
+  server: <T extends DataWithOptionalCause>(opts: ServerErrorOptions<T>) => {
     if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
       throw new Error(
         'Ethereum RPC Server errors must provide single object argument.',
@@ -91,7 +94,7 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  invalidInput: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+  invalidInput: <T extends DataWithOptionalCause>(arg?: JsonRpcErrorsArg<T>) =>
     getJsonRpcError(errorCodes.rpc.invalidInput, arg),
 
   /**
@@ -100,8 +103,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  resourceNotFound: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.resourceNotFound, arg),
+  resourceNotFound: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.resourceNotFound, arg),
 
   /**
    * Get an Ethereum JSON RPC Resource Unavailable (-32002) error.
@@ -109,8 +113,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  resourceUnavailable: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.resourceUnavailable, arg),
+  resourceUnavailable: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.resourceUnavailable, arg),
 
   /**
    * Get an Ethereum JSON RPC Transaction Rejected (-32003) error.
@@ -118,8 +123,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  transactionRejected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.transactionRejected, arg),
+  transactionRejected: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.transactionRejected, arg),
 
   /**
    * Get an Ethereum JSON RPC Method Not Supported (-32004) error.
@@ -127,8 +133,9 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  methodNotSupported: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
-    getJsonRpcError(errorCodes.rpc.methodNotSupported, arg),
+  methodNotSupported: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => getJsonRpcError(errorCodes.rpc.methodNotSupported, arg),
 
   /**
    * Get an Ethereum JSON RPC Limit Exceeded (-32005) error.
@@ -136,7 +143,7 @@ export const rpcErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link JsonRpcError} class.
    */
-  limitExceeded: <T extends Json>(arg?: JsonRpcErrorsArg<T>) =>
+  limitExceeded: <T extends DataWithOptionalCause>(arg?: JsonRpcErrorsArg<T>) =>
     getJsonRpcError(errorCodes.rpc.limitExceeded, arg),
 };
 
@@ -147,7 +154,9 @@ export const providerErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  userRejectedRequest: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+  userRejectedRequest: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => {
     return getEthProviderError(errorCodes.provider.userRejectedRequest, arg);
   },
 
@@ -157,7 +166,9 @@ export const providerErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  unauthorized: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+  unauthorized: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => {
     return getEthProviderError(errorCodes.provider.unauthorized, arg);
   },
 
@@ -167,7 +178,9 @@ export const providerErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  unsupportedMethod: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+  unsupportedMethod: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => {
     return getEthProviderError(errorCodes.provider.unsupportedMethod, arg);
   },
 
@@ -177,7 +190,9 @@ export const providerErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  disconnected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+  disconnected: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => {
     return getEthProviderError(errorCodes.provider.disconnected, arg);
   },
 
@@ -187,7 +202,9 @@ export const providerErrors = {
    * @param arg - The error message or options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  chainDisconnected: <T extends Json>(arg?: JsonRpcErrorsArg<T>) => {
+  chainDisconnected: <T extends DataWithOptionalCause>(
+    arg?: JsonRpcErrorsArg<T>,
+  ) => {
     return getEthProviderError(errorCodes.provider.chainDisconnected, arg);
   },
 
@@ -197,7 +214,7 @@ export const providerErrors = {
    * @param opts - The error options bag.
    * @returns An instance of the {@link EthereumProviderError} class.
    */
-  custom: <T extends Json>(opts: CustomErrorArg<T>) => {
+  custom: <T extends DataWithOptionalCause>(opts: CustomErrorArg<T>) => {
     if (!opts || typeof opts !== 'object' || Array.isArray(opts)) {
       throw new Error(
         'Ethereum Provider custom errors must provide single object argument.',
@@ -220,7 +237,7 @@ export const providerErrors = {
  * @param arg - The error message or options bag.
  * @returns An instance of the {@link JsonRpcError} class.
  */
-function getJsonRpcError<T extends Json>(
+function getJsonRpcError<T extends DataWithOptionalCause>(
   code: number,
   arg?: JsonRpcErrorsArg<T>,
 ): JsonRpcError<T> {
@@ -235,7 +252,7 @@ function getJsonRpcError<T extends Json>(
  * @param arg - The error message or options bag.
  * @returns An instance of the {@link EthereumProviderError} class.
  */
-function getEthProviderError<T extends Json>(
+function getEthProviderError<T extends DataWithOptionalCause>(
   code: number,
   arg?: JsonRpcErrorsArg<T>,
 ): EthereumProviderError<T> {
@@ -253,7 +270,7 @@ function getEthProviderError<T extends Json>(
  * @param arg - The error message or options bag.
  * @returns A tuple containing the error message and optional data.
  */
-function parseOpts<T extends Json>(
+function parseOpts<T extends DataWithOptionalCause>(
   arg?: JsonRpcErrorsArg<T>,
 ): [message?: string | undefined, data?: T | undefined] {
   if (arg) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,5 @@
-import { JsonRpcError, EthereumProviderError } from './classes';
-import { serializeError, getMessageFromCode } from './utils';
-import { rpcErrors, providerErrors } from './errors';
-import { errorCodes } from './error-constants';
-
-export {
-  errorCodes,
-  rpcErrors,
-  providerErrors,
-  JsonRpcError,
-  EthereumProviderError,
-  serializeError,
-  getMessageFromCode,
-};
+export { JsonRpcError, EthereumProviderError } from './classes';
+export { serializeCause, serializeError, getMessageFromCode } from './utils';
+export type { DataWithOptionalCause } from './utils';
+export { rpcErrors, providerErrors } from './errors';
+export { errorCodes } from './error-constants';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,20 @@ import {
 } from '@metamask/utils';
 import { errorCodes, errorValues } from './error-constants';
 
+/**
+ * A data object, that must be either:
+ *
+ * - A JSON-serializable object.
+ * - An object with a `cause` property that is an `Error` instance, and any
+ * other properties that are JSON-serializable.
+ */
+export type DataWithOptionalCause =
+  | Json
+  | {
+      [key: string]: Json | Error;
+      cause: Error;
+    };
+
 const FALLBACK_ERROR_CODE = errorCodes.rpc.internal;
 const FALLBACK_MESSAGE =
   'Unspecified error message. This is a bug, please report it.';
@@ -143,7 +157,7 @@ function isJsonRpcServerError(code: number): boolean {
  * @param error - The unknown error.
  * @returns A JSON-serializable object containing as much information about the original error as possible.
  */
-function serializeCause(error: unknown): Json {
+export function serializeCause(error: unknown): Json {
   if (Array.isArray(error)) {
     return error.map((entry) => {
       if (isValidJson(entry)) {


### PR DESCRIPTION
This allows passing an `Error` class object to one of the predefined error functions as defined in `rpcErrors` and `providerErrors`. Upon calling the `serialise` function of the `JsonRpcError` class, the cause error will be serialised using the `serializeCause` function.

For example:

```ts
const error = rpcErrors.invalidParams({
  data: {
    cause: new Error('foo bar'),
  },
});
```

Callng `error.serialize()` results in:

```json
{
  "code": -32602,
  "message": "Invalid method parameter(s).",
  "data": {
    "cause": {
      "stack": "Error: foo bar [...]",
      "message": "foo bar"
    }
  },
  "stack": "Error: Invalid method parameter(s). [...]"
}
```