### PR TITLE
Export `OptionalDataWithOptionalCause` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { JsonRpcError, EthereumProviderError } from './classes';
 export { serializeCause, serializeError, getMessageFromCode } from './utils';
-export type { DataWithOptionalCause } from './utils';
+export type {
+  DataWithOptionalCause,
+  OptionalDataWithOptionalCause,
+} from './utils';
 export { rpcErrors, providerErrors } from './errors';
 export { errorCodes } from './error-constants';


### PR DESCRIPTION
This type is used in the public API, but currently not exported. This fixes it.