### PR TITLE
feat: propagate data.cause as cause in JsonRpcError constructor

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 92.64,
+      branches: 93.05,
       functions: 94.44,
-      lines: 92.85,
-      statements: 92.85,
+      lines: 92.96,
+      statements: 92.96,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.05,
-      functions: 94.44,
-      lines: 92.96,
-      statements: 92.96,
+      branches: 91.89,
+      functions: 94.59,
+      lines: 92.42,
+      statements: 92.42,
     },
   },
 

--- a/src/__fixtures__/errors.ts
+++ b/src/__fixtures__/errors.ts
@@ -1,7 +1,11 @@
 import { rpcErrors } from '..';
 
-export const dummyData = { foo: 'bar' };
 export const dummyMessage = 'baz';
+export const dummyData = { foo: 'bar' };
+export const dummyDataWithCause = {
+  foo: 'bar',
+  cause: { message: dummyMessage },
+};
 
 export const invalidError0 = 0;
 export const invalidError1 = ['foo', 'bar', 3];

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -2,7 +2,7 @@ import type {
   Json,
   JsonRpcError as SerializedJsonRpcError,
 } from '@metamask/utils';
-import { isPlainObject } from '@metamask/utils';
+import { hasProperty, isPlainObject } from '@metamask/utils';
 import safeStringify from 'fast-safe-stringify';
 
 import type { OptionalDataWithOptionalCause } from './utils';
@@ -40,7 +40,7 @@ export class JsonRpcError<
       super(message, { cause: data.cause });
 
       // Browser backwards-compatibility fallback
-      if (!Object.prototype.hasOwnProperty.call(this, 'cause')) {
+      if (!hasProperty(this, 'cause')) {
         Object.assign(this, { cause: data.cause });
       }
     } else {

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -2,7 +2,7 @@ import type {
   Json,
   JsonRpcError as SerializedJsonRpcError,
 } from '@metamask/utils';
-import { isPlainObject } from '@metamask/utils';
+import { hasProperty, isObject, isPlainObject } from '@metamask/utils';
 import safeStringify from 'fast-safe-stringify';
 
 import type { OptionalDataWithOptionalCause } from './utils';
@@ -19,6 +19,9 @@ export type { SerializedJsonRpcError };
 export class JsonRpcError<
   Data extends OptionalDataWithOptionalCause,
 > extends Error {
+  // This can be removed when tsconfig lib and/or target have changed to >=es2022
+  public cause: OptionalDataWithOptionalCause;
+
   public code: number;
 
   public data?: Data;
@@ -36,6 +39,13 @@ export class JsonRpcError<
     this.code = code;
     if (data !== undefined) {
       this.data = data;
+      if (
+        isObject(data) &&
+        hasProperty(data, 'cause') &&
+        isObject(data.cause)
+      ) {
+        this.cause = data.cause;
+      }
     }
   }
 

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -19,7 +19,7 @@ export type { SerializedJsonRpcError };
 export class JsonRpcError<
   Data extends OptionalDataWithOptionalCause,
 > extends Error {
-  // The `cause` field can be removed when tsconfig lib and/or target have changed to >=es2022
+  // The `cause` definition can be removed when tsconfig lib and/or target have changed to >=es2022
   public cause?: unknown;
 
   public code: number;

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -3,6 +3,8 @@ import { assert, isPlainObject } from '@metamask/utils';
 import { rpcErrors, providerErrors, errorCodes } from '.';
 import {
   dummyData,
+  dummyDataWithCause,
+  dummyMessage,
   CUSTOM_ERROR_MESSAGE,
   SERVER_ERROR_CODE,
   CUSTOM_ERROR_CODE,
@@ -97,6 +99,21 @@ describe('rpcErrors', () => {
     },
   );
 
+  it.each(Object.entries(rpcErrors).filter(([key]) => key !== 'server'))(
+    '%s propagates data.cause if set',
+    (key, value) => {
+      const createError = value as any;
+      const error = createError({
+        message: null,
+        data: Object.assign({}, dummyDataWithCause),
+      });
+      // @ts-expect-error TypeScript does not like indexing into this with the key
+      const rpcCode = errorCodes.rpc[key];
+      expect(error.message).toBe(getMessageFromCode(rpcCode));
+      expect(error.cause.message).toBe(dummyMessage);
+    },
+  );
+
   it('serializes a cause', () => {
     const error = rpcErrors.invalidInput({
       data: {
@@ -153,6 +170,21 @@ describe('providerErrors', () => {
       expect(error.code >= 1000 && error.code < 5000).toBe(true);
       expect(error.code).toBe(providerCode);
       expect(error.message).toBe(getMessageFromCode(providerCode));
+    },
+  );
+
+  it.each(Object.entries(providerErrors).filter(([key]) => key !== 'custom'))(
+    '%s propagates data.cause if set',
+    (key, value) => {
+      const createError = value as any;
+      const error = createError({
+        message: null,
+        data: Object.assign({}, dummyDataWithCause),
+      });
+      // @ts-expect-error TypeScript does not like indexing into this with the key
+      const providerCode = errorCodes.provider[key];
+      expect(error.message).toBe(getMessageFromCode(providerCode));
+      expect(error.cause.message).toBe(dummyMessage);
     },
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { JsonRpcError, EthereumProviderError } from './classes';
-export { serializeCause, serializeError, getMessageFromCode } from './utils';
+export {
+  dataHasCause,
+  serializeCause,
+  serializeError,
+  getMessageFromCode,
+} from './utils';
 export type {
   DataWithOptionalCause,
   OptionalDataWithOptionalCause,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -16,7 +16,7 @@ import {
   dummyMessage,
   dummyData,
 } from './__fixtures__';
-import { getMessageFromCode, serializeError } from './utils';
+import { dataHasCause, getMessageFromCode, serializeError } from './utils';
 
 const rpcCodes = errorCodes.rpc;
 
@@ -308,5 +308,25 @@ describe('serializeError', () => {
         cause: ['foo', null, { baz: 'qux' }],
       },
     });
+  });
+});
+
+describe('dataHasCause', () => {
+  it('returns false for invalid data types', () => {
+    [undefined, null, 'hello', 1234].forEach((data) => {
+      const result = dataHasCause(data);
+      expect(result).toBe(false);
+    });
+  });
+  it('returns false for invalid cause types', () => {
+    [undefined, null, 'hello', 1234].forEach((cause) => {
+      const result = dataHasCause({ cause });
+      expect(result).toBe(false);
+    });
+  });
+  it('returns true when cause is object', () => {
+    const data = { cause: {} };
+    const result = dataHasCause(data);
+    expect(result).toBe(true);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,3 +211,16 @@ function serializeObject(object: RuntimeObject): Json {
     {},
   );
 }
+
+/**
+ * Returns true if supplied error data has a usable `cause` property; false otherwise.
+ *
+ * @param data - Optional data to validate.
+ * @returns Whether cause property is present and an object.
+ */
+export function dataHasCause(data: unknown): data is {
+  [key: string]: Json | unknown;
+  cause: object;
+} {
+  return isObject(data) && hasProperty(data, 'cause') && isObject(data.cause);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
+    // Remove custom `cause` field from JsonRpcError when updating
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    // Remove custom `cause` field from JsonRpcError when updating
+    // Reminder: Remove custom `cause` field from JsonRpcError when enabling es2022
     "lib": ["ES2020"],
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
This maps the [tc39](https://tc39.es/proposal-error-cause/) error `cause` field on `JsonRpcError` instances to `data.cause`, if it exists and is an object. No further validation is performed.

This is done because adding `es2022` or `dom` to tsconfig lib are not being considered at this point.



### Related
- #129
- #83
- #91 
- #102

### Alternative
- #141 