### PR TITLE
chore(tsconfig): bump lib from es2020 to es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
This requires change tsconfig [`lib`](https://www.typescriptlang.org/tsconfig/#lib) from `ES2020` to `ES2022`.

It incurs no changes on the built package `dist`.

#### Blocking
- #141