### PR TITLE
fix: Add root index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>@metamask/rpc-errors</title>
+  <meta http-equiv="refresh" content="0; url=./latest" />
+</head>
+</html>


### PR DESCRIPTION
Adds an `index.html` file to the root directory of `gh-pages`, such that going straight to https://metamask.github.io/rpc-errors/ redirects to `/latest` instead of returning a 404.