### PR TITLE
chore: remove incompatible Hermes serialization code

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -75,11 +75,7 @@ export class JsonRpcError<
         serialized.data.cause = serializeCause(this.data.cause);
       }
     }
-
-    if (this.stack) {
-      serialized.stack = this.stack;
-    }
-
+    
     return serialized;
   }
 


### PR DESCRIPTION
* What is the current state of things and why does it need to change?
  * The serialization of the error stack which is not supported by the Hermes engine and causes a crash on applications running.
* What is the solution your changes offer and how does it work?
  * This PR removes the serialization of the error stack 

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:
* See: https://github.com/MetaMask/metamask-mobile/pull/12147

